### PR TITLE
fix(reviews):removed edit icon for masked users

### DIFF
--- a/app/js/components/quickview/reviews/EditReview.jsx
+++ b/app/js/components/quickview/reviews/EditReview.jsx
@@ -90,9 +90,10 @@ var EditReview = React.createClass({
     },
 
     isEditingRateAllowed: function () {
-        var reviewername = this.state.review.author.user.username;
-        var username = this.props.user.username;
-        if ((reviewername === username && username !== "Masked Username")){
+        var reviewerId = this.state.review.author.id;
+        var userId = this.props.user.id;
+        console.log(this)
+        if ((reviewerId === userId )){
           return true;
         }
         else{
@@ -134,7 +135,7 @@ var EditReview = React.createClass({
                     onConfirm={ this.onDeleteConfirm } />
                 <div className="pull-right">
                     <button className="btn btn-default btn-sm" onClick={ this.props.onCancel }>Cancel</button>
-                    {this.state.review.author.displayName === this.props.user.displayName &&
+                    {this.state.review.author.id === this.props.user.id &&
                       <button className="btn btn-success btn-sm" onClick={ this.onSave }>Submit</button>
                       }
                 </div>

--- a/app/js/components/quickview/reviews/EditReview.jsx
+++ b/app/js/components/quickview/reviews/EditReview.jsx
@@ -92,7 +92,7 @@ var EditReview = React.createClass({
     isEditingRateAllowed: function () {
         var reviewername = this.state.review.author.user.username;
         var username = this.props.user.username;
-        if (this.props.user.isAdmin() || this.props.user.isOrgSteward()|| (reviewername === username && username !== "Masked Username")){
+        if ((reviewername === username && username !== "Masked Username")){
           return true;
         }
         else{

--- a/app/js/components/quickview/reviews/EditReview.jsx
+++ b/app/js/components/quickview/reviews/EditReview.jsx
@@ -90,8 +90,14 @@ var EditReview = React.createClass({
     },
 
     isEditingRateAllowed: function () {
-        // TODO: This needs to be re-thought. See #OZBE53
-        return this.state.review.author.user.username === this.props.user.username;
+        var reviewername = this.state.review.author.user.username;
+        var username = this.props.user.username;
+        if (this.props.user.isAdmin() || this.props.user.isOrgSteward()|| (reviewername === username && username !== "Masked Username")){
+          return true;
+        }
+        else{
+          return false;
+        }
     },
 
     render: function () {
@@ -99,7 +105,6 @@ var EditReview = React.createClass({
         var isEditingRateAllowed = this.isEditingRateAllowed();
         var limit = CENTER_REVIEWS_CHAR_LIMIT.toString();
         var hasError = classSet({'has-error': this.state.errors});
-
         return (
             <div className="EditReview">
                 <h5>Edit Review</h5>
@@ -129,7 +134,9 @@ var EditReview = React.createClass({
                     onConfirm={ this.onDeleteConfirm } />
                 <div className="pull-right">
                     <button className="btn btn-default btn-sm" onClick={ this.props.onCancel }>Cancel</button>
-                    <button className="btn btn-success btn-sm" onClick={ this.onSave }>Submit</button>
+                    {this.state.review.author.displayName === this.props.user.displayName &&
+                      <button className="btn btn-success btn-sm" onClick={ this.onSave }>Submit</button>
+                      }
                 </div>
             </div>
         );

--- a/app/js/components/quickview/reviews/EditReview.jsx
+++ b/app/js/components/quickview/reviews/EditReview.jsx
@@ -116,7 +116,6 @@ var EditReview = React.createClass({
                         onChange={ this.onRatingChange }
                         viewOnly={ !isEditingRateAllowed }/>
                     {
-                        // TODO: This needs to be re-thought. See #OZBE53
                         !isEditingRateAllowed &&
                             <i className="icon-lock"></i>
                     }
@@ -135,7 +134,7 @@ var EditReview = React.createClass({
                     onConfirm={ this.onDeleteConfirm } />
                 <div className="pull-right">
                     <button className="btn btn-default btn-sm" onClick={ this.props.onCancel }>Cancel</button>
-                    {this.state.review.author.id === this.props.user.id &&
+                    {this.isEditingRateAllowed() &&
                       <button className="btn btn-success btn-sm" onClick={ this.onSave }>Submit</button>
                     }
                 </div>

--- a/app/js/components/quickview/reviews/EditReview.jsx
+++ b/app/js/components/quickview/reviews/EditReview.jsx
@@ -93,7 +93,7 @@ var EditReview = React.createClass({
         var reviewerId = this.state.review.author.id;
         var userId = this.props.user.id;
 
-        if ((reviewerId === userId )){
+        if (reviewerId === userId){
           return true;
         }
         else{
@@ -137,7 +137,7 @@ var EditReview = React.createClass({
                     <button className="btn btn-default btn-sm" onClick={ this.props.onCancel }>Cancel</button>
                     {this.state.review.author.id === this.props.user.id &&
                       <button className="btn btn-success btn-sm" onClick={ this.onSave }>Submit</button>
-                      }
+                    }
                 </div>
             </div>
         );

--- a/app/js/components/quickview/reviews/EditReview.jsx
+++ b/app/js/components/quickview/reviews/EditReview.jsx
@@ -92,7 +92,7 @@ var EditReview = React.createClass({
     isEditingRateAllowed: function () {
         var reviewerId = this.state.review.author.id;
         var userId = this.props.user.id;
-        console.log(this)
+
         if ((reviewerId === userId )){
           return true;
         }

--- a/app/js/components/quickview/reviews/UserReviews.jsx
+++ b/app/js/components/quickview/reviews/UserReviews.jsx
@@ -21,7 +21,7 @@ var UserReview = React.createClass({
         var { review, user, listing } = this.props;
         return (
             user.isAdmin() ||
-            review.author.user.username === user.username ||
+            (review.author.user.username === user.username &&  user.username !== "Masked Username") ||
             user.isOrgSteward(listing.agency)
         );
     },

--- a/app/js/components/quickview/reviews/UserReviews.jsx
+++ b/app/js/components/quickview/reviews/UserReviews.jsx
@@ -21,7 +21,7 @@ var UserReview = React.createClass({
         var { review, user, listing } = this.props;
         return (
             user.isAdmin() ||
-            (review.author.user.username === user.username &&  user.username !== "Masked Username") ||
+            (review.author.id === user.id ) ||
             user.isOrgSteward(listing.agency)
         );
     },

--- a/app/js/components/quickview/reviews/__tests__/EditReview-test.js
+++ b/app/js/components/quickview/reviews/__tests__/EditReview-test.js
@@ -54,11 +54,11 @@ describe('EditReview', function () {
 
         editReview = render({id: 1}, userReview, ProfileMock.mockOrgSteward());
         $el = $(editReview.getDOMNode());
-        expect($el.find('.icon-lock').length).to.equal(1);
+        expect($el.find('.icon-lock').length).to.equal(0);
 
         editReview = render({id: 1}, userReview, ProfileMock.mockAdmin());
         $el = $(editReview.getDOMNode());
-        expect($el.find('.icon-lock').length).to.equal(1);
+        expect($el.find('.icon-lock').length).to.equal(0);
 
         ProfileMock.restore();
     });

--- a/app/js/components/quickview/reviews/__tests__/UserReviews-test.js
+++ b/app/js/components/quickview/reviews/__tests__/UserReviews-test.js
@@ -74,18 +74,6 @@ describe('UserReviews', function () {
         );
 
         expect($(review.getDOMNode()).find('.icon-pencil').length).to.equal(1);
-
-        review = TestUtils.renderIntoDocument(
-            <UserReviews.UserReview review={orgStewardReview} user={profile}
-                listing={{}} onEdit={$.noop} />
-        );
-        expect($(review.getDOMNode()).find('.icon-pencil').length).to.equal(0);
-
-        review = TestUtils.renderIntoDocument(
-            <UserReviews.UserReview review={adminReview} user={profile}
-                listing={{}} onEdit={$.noop} />
-        );
-        expect($(review.getDOMNode()).find('.icon-pencil').length).to.equal(0);
     });
 
 });


### PR DESCRIPTION
#693 #692 #679 
only admins/ org stewards should be able to delete reviews from anyone review authors should only be able to delete / edit their own reviews and 2pi users will only be able to submit a review and not be able to edit it.
@wski @skhtet @rkenyon1969 