### PR TITLE
fix(Carousel): Fixed arrows disappearing when tabbing into carousel #524

### DIFF
--- a/app/js/components/carousel/index.jsx
+++ b/app/js/components/carousel/index.jsx
@@ -27,13 +27,13 @@ var Carousel = React.createClass({
 
         return (
             <div className={classes} {...other}>
+                <button className="prev btn hidden" href="#" ref="prev" aria-label="previous carousel button"><i className="icon-caret-left-white" alt=""></i></button>
+                <button className="next btn hidden" href="#" ref="next" aria-label="next carousel button"><i className="icon-caret-right-white" alt=""></i></button>
                 <div className="carousel">
                     <ul ref="list" className="list-unstyled">
                         { this.props.children }
                     </ul>
                     <div className="clearfix"></div>
-                    <button className="prev btn hidden" href="#" ref="prev" aria-label="previous carousel button"><i className="icon-caret-left-white" alt=""></i></button>
-                    <button className="next btn hidden" href="#" ref="next" aria-label="next carousel button"><i className="icon-caret-right-white" alt=""></i></button>
                 </div>
             </div>
         );


### PR DESCRIPTION
Fixed the arrow buttons disappearing by moving them into the parent container so that they did not move when tabbing @akonsowski @blynch11p 