### PR TITLE
Re-init-ing Notifications after a new fetch.

### DIFF
--- a/app/js/stores/ActiveNotificationStore.js
+++ b/app/js/stores/ActiveNotificationStore.js
@@ -20,6 +20,7 @@ var ActiveNotificationStore = Reflux.createStore({
     },
 
     fetchActiveCompleted(notifications) {
+        this.init();
         _notifications.receivePage(notifications);
         this.trigger();
     },


### PR DESCRIPTION
@lsemesky @akonsowski @rkenyon1969 
The notifications were being built on top of each other over and over causing non-unique keys, this re-inits the notifications after a completed fetch.