### PR TITLE
Updating for site-wide consistency.

### DIFF
--- a/app/js/components/management/mall/notifications/CreateNotification.jsx
+++ b/app/js/components/management/mall/notifications/CreateNotification.jsx
@@ -101,7 +101,7 @@ var CreateNotification = React.createClass({
                         </div>
                         <div className="col-md-6">
                             <div className="form-group">
-                                <label>Expires At (Zulu Time)</label>
+                                <label>Expires At (Z)</label>
                                 <div>
                                     <Select ref="hour" name="hour" options={ this.props.hours } valueLink={ this.linkState('hour') } />
                                     <Select ref="minute" name="minute" options={ this.props.minutes } valueLink={ this.linkState('minute') } />


### PR DESCRIPTION
@lsemesky @akonsowski @tdressel 

Changing the Zulu Time to Z to match the other commit for consistency.  There's no need to spell out Zulu.