### PR TITLE
fixed pending deletion alignment

### DIFF
--- a/app/styles/management/user/_my-listings.scss
+++ b/app/styles/management/user/_my-listings.scss
@@ -113,7 +113,7 @@
         }
     }
 
-    .label-draft, .label-pending, .label-needs-action, .label-published, .label-rejected {
+    .label-draft, .label-pending, .label-needs-action, .label-published, .label-rejected, .label-pending-delete {
         i { 
             float: left;
         }


### PR DESCRIPTION
@blynch11p @mleeBoeing in order to give a thumbs up for this you need to checkout this branch and make sure it works according to the following details:

  
![image](https://cloud.githubusercontent.com/assets/2533916/23873177/743abc7e-0807-11e7-8847-d9fb981ddffb.png)

Other categories word wrap in line with the first word when browser is resized. May need to add a missing css class somewhere to conform

Then either :+1:  (+1 inside of colons) or leave comments on the code