### PR TITLE
Fixing a typo (-center)

### DIFF
--- a/app/js/webapi/__tests__/api-listing-response.js
+++ b/app/js/webapi/__tests__/api-listing-response.js
@@ -61,7 +61,7 @@ var listing = {
         {
             "id": 1,
             "contact_type": {
-                "name": "Civillian"
+                "name": "Civilian"
             },
             "secure_phone": null,
             "unsecure_phone": "321-123-7894",


### PR DESCRIPTION
ozp-center, ozp-backend, and ozp-react-commons all have this typo and a PR to match. (Civilian vs Civillian)

@mannyrivera2010 @lsemesky @mleeBoeing @J-Fid 

