### PR TITLE
Adding tracking to the Recommended and Similar Listing tiles.

### DIFF
--- a/app/js/analytics/ozp-analytics.js
+++ b/app/js/analytics/ozp-analytics.js
@@ -31,5 +31,9 @@ module.exports = {
 
     trackListingReviewView: function(listingName, agency){
         window._paq.push(['trackEvent', 'Listing Review View', listingName, agency]);
+    },
+
+    trackRecommender: function(type, application){
+        window._paq.push(['trackEvent', type, application]);
     }
 };

--- a/app/js/components/discovery/ListingTile.jsx
+++ b/app/js/components/discovery/ListingTile.jsx
@@ -6,15 +6,18 @@ var ActiveState = require('../../mixins/ActiveStateMixin');
 var IconRating = require('../shared/IconRating.jsx');
 var CenterLaunchLink = require('../CenterLaunchLink.jsx');
 var BookmarkButton = require('../BookmarkButton.jsx');
+var OzpAnalytics = require('../../analytics/ozp-analytics');
+var { listingMessages } = require('ozp-react-commons/constants/messages');
 
 var ListingTile = React.createClass({
 
     mixins: [Navigation, CurrentPath, ActiveState],
 
     statics: {
-        fromArray: function (array) {
+        fromArray: function (array, from) {
+            if(!from) from = '';
             return array.map(function(listing, i) {
-                return <ListingTile listing={listing} key={`${listing.id}.${i}`}/>;
+                return <ListingTile from={from} listing={listing} key={`${listing.id}.${i}`}/>;
             });
         },
         renderLimitedTiles: function(display, mostPopular) {
@@ -25,6 +28,13 @@ var ListingTile = React.createClass({
                 }).map((tile, i) => <ListingTile listing={tile} key={`${tile.id}.${i}`}/>)
             );
         }
+    },
+
+    handleClick: function(from, title) {
+      if(from){
+        if(from == listingMessages['recommender.recommended'])
+          OzpAnalytics.trackRecommender(listingMessages['recommender.recommended'], title);
+      }
     },
 
     render: function () {
@@ -43,7 +53,7 @@ var ListingTile = React.createClass({
         imageLargeUrl = listing.imageLargeUrl;
 
         return (
-            <li className="listing SearchListingTile">
+            <li onClick={this.handleClick.bind(this, this.props.from, listing.title)} className="listing SearchListingTile">
                 <a className="listing-link"  href={ href }>
                     {/* Empty link - css will make it cover entire <li>*/}
                     <span className="hidden-span">{listing.title}</span>

--- a/app/js/components/discovery/RecommendedListingTile.jsx
+++ b/app/js/components/discovery/RecommendedListingTile.jsx
@@ -7,6 +7,8 @@ var IconRating = require('../shared/IconRating.jsx');
 var CenterLaunchLink = require('../CenterLaunchLink.jsx');
 var BookmarkButton = require('../BookmarkButton.jsx');
 var CurrentListingStore = require('../../stores/CurrentListingStore.js');
+var OzpAnalytics = require('../../analytics/ozp-analytics');
+var { listingMessages } = require('ozp-react-commons/constants/messages');
 
 var RecommendedListingTile = React.createClass({
 
@@ -28,8 +30,9 @@ var RecommendedListingTile = React.createClass({
         }
     },
 
-    loadRecommendation: function (recommendationId) {
-        CurrentListingStore.loadListing(recommendationId);
+    loadRecommendation: function (recommendation) {
+        OzpAnalytics.trackRecommender(listingMessages['recommender.similar'], recommendation.title);
+        CurrentListingStore.loadListing(recommendation.id);
     },
 
     render: function () {
@@ -46,15 +49,15 @@ var RecommendedListingTile = React.createClass({
         var labelStyle = {
             paddingLeft: '10px'
         };
-var lockStyle = {
+        var lockStyle = {
             position: 'absolute',
             left: '4px',
             top: '4px'
         };
-       
+
 
         return (
-            <div className="recommendations-tile" onClick ={this.loadRecommendation.bind(this,listing.id)} >
+            <div className="recommendations-tile" onClick={this.loadRecommendation.bind(this,listing)} >
                 <div className="quickview-header-info">
                     <img className="listing-icon" alt={`${listing.title} header information`} src={ image } data-fallback="/store/images/types/3" />
                     <h3 className="listing-title" tabIndex="0" title={ title }>{ title }
@@ -77,7 +80,7 @@ var lockStyle = {
                         halfClassName="icon-star-half-filled-yellow" />
                 </div>
                 </div>
-                
+
         );
     }
 });

--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -6,6 +6,7 @@ var { Navigation } = require('react-router');
 var _ = require('../../utils/_');
 var {CENTER_URL, API_URL} = require('ozp-react-commons/OzoneConfig');
 var { PAGINATION_MAX } = require('ozp-react-commons/constants');
+var { listingMessages } = require('ozp-react-commons/constants/messages');
 
 // actions
 var ListingActions = require('../../actions/ListingActions');
@@ -382,9 +383,9 @@ var Discovery = React.createClass({
         if(this.state.recommended.length){
             return (
                 <section className="Discovery__Recommended" key="Discovery__Recommended">
-                <h4>Recommended For You</h4>
+                <h4>{listingMessages['recommender.recommended']}</h4>
                 <Carousel className="new-arrival-listings" aria-label="Recommended Apps Carousel">
-                    { ListingTile.fromArray(this.state.recommended) }
+                    { ListingTile.fromArray(this.state.recommended, listingMessages['recommender.recommended']) }
                 </Carousel>
             </section>
             );

--- a/app/js/components/quickview/Recommendations.jsx
+++ b/app/js/components/quickview/Recommendations.jsx
@@ -11,6 +11,7 @@ var CenterLaunchLink = require('../CenterLaunchLink.jsx');
 var Carousel = require('../carousel/index.jsx');
 var CurrentListingStore = require('../../stores/CurrentListingStore');
 var ListingActions = require('../../actions/ListingActions.js');
+var { listingMessages } = require('ozp-react-commons/constants/messages');
 var QuickViewRecommendations = React.createClass({
     mixins: [
         Reflux.listenTo(CurrentListingStore, 'onFetchSimilarCompleted'),
@@ -28,7 +29,7 @@ var QuickViewRecommendations = React.createClass({
         listing: React.PropTypes.object,
         shown: React.PropTypes.bool,
     },
-    
+
     getDefaultProps: function () {
         return {
             shown: false
@@ -72,9 +73,10 @@ var QuickViewRecommendations = React.createClass({
         return (
             <div className="quickview-recommendations" >
                 <div className="quickview-recommendations-info">
-                    <h3 className="recommendations-title" tabIndex="0" title="Similar Listings">Similar Listings
+                    <h3 className="recommendations-title" tabIndex="0" title={listingMessages['recommender.similar']}>
+                      {listingMessages['recommender.similar']}
                     </h3>
-                    
+
                    <div>{this.renderSimilar()}</div>
                 </div>
                </div>


### PR DESCRIPTION
Needs the recommender_constants branch from ozp-react-commons.

After adding the code, you can see the tracking being sent through the browser to Piwik when clicking a Recommended or Similar Listing tile.

Piwik UI will show the events.

@lsemesky @mleeBoeing @rkenyon1969 