### PR TITLE
Putting checks in place for changeLog to not be undefined

### DIFF
--- a/app/js/components/shared/ChangeLog.jsx
+++ b/app/js/components/shared/ChangeLog.jsx
@@ -253,8 +253,9 @@ var ChangeLog = React.createClass({
             link = this.props.children[1];
         }
 
-        var time = timeAgo(this.props.changeLog.activityDate);
-        var Handler = this.actionMapAdmin[this.props.changeLog.action];
+        var changeLog = this.props.changeLog;
+        var time = changeLog ? timeAgo(changeLog.activityDate) : null;
+        var Handler = changeLog ? this.actionMapAdmin[changeLog.action] : null;
         if(!Handler) {
             Handler = GenericLegacyChangeLog;
         }
@@ -266,7 +267,7 @@ var ChangeLog = React.createClass({
                     </div>
                     <div className={this.props.showListingName ? "col-md-10" : "col-md-9"}>
                         { icon }
-                        < Handler changeLog={ this.props.changeLog } listingName={ this.getListingName() } />
+                        { changeLog ? < Handler changeLog={ changeLog } listingName={ this.getListingName() } /> : null }
                         { link }
                     </div>
                 </div>


### PR DESCRIPTION
Correcting a minor bug that was putting a `this.state.changeLog is undefined` message in the browser console if a user continuously clicked the Enabled and Featured toggles in the Adminisrtation tab of an Application.

@lsemesky @mleeBoeing @rkenyon1969 @J-Fid 