### PR TITLE
Launch notice of requirements

### DIFF
--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -64,25 +64,25 @@ var CenterLaunchLink = React.createClass({
         var launchWarning = this.state.launchModal;
         var requirements = this.props.listing.requirements;
         var launchModal = requirements != '' && requirements.toLowerCase() != 'none'
-          ? (<Modal ref="modal" className="LaunchConfirmation" size="small" title="Launch Requirements Notice" onCancel={this.modalConfimation}>
-            <strong>
-                <p>Please review the requirements below if you have problems launching <b>{this.props.listing.title}</b></p>
-                <br/>
-                <p>{this.props.listing.requirements}</p>
-                <br/>
-                <p>This dialog box will close automatically after 10 seconds</p>
-            </strong>
-            <button className="btn btn-danger" onClick={this.modalConfimation}>OK</button>
-        </Modal>) : null;
+            ? (<Modal ref="modal" className="LaunchConfirmation" size="small" title="Launch Requirements Notice" onCancel={this.modalConfimation}>
+                  <strong>
+                      <p>Please review the requirements below if you have problems launching <b>{this.props.listing.title}</b></p>
+                      <br/>
+                      <p>{this.props.listing.requirements}</p>
+                      <br/>
+                      <p>This dialog box will close automatically after 10 seconds</p>
+                  </strong>
+                  <button className="btn btn-danger" onClick={this.modalConfimation}>OK</button>
+              </Modal>)
+          : null;
 
         return (
             <div style={{float: 'left'}}>
-              <button ref="tooltipped" data-toggle="tooltip" data-placement="top" alt="Click to launch this app" title="Launch" { ...otherProps } className={linkClassName}
-                      onClick={this.launchClick}>
-                  <i className="icon-open-grayDark" /><span className="hidden-span">Launch</span>
-
-              </button>
-              {launchWarning ? launchModal : null}
+                <button ref="tooltipped" data-toggle="tooltip" data-placement="top" alt="Click to launch this app" title="Launch" { ...otherProps } className={linkClassName}
+                        onClick={this.launchClick}>
+                    <i className="icon-open-grayDark" /><span className="hidden-span">Launch</span>
+                </button>
+                {launchWarning ? launchModal : null}
             </div>
         );
     }

--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -13,7 +13,7 @@ function getState(profileData) {
     var profile = profileData.currentUser,
         launchInWebtop = profile ? profile.launchInWebtop : false;
 
-    return {launchInWebtop: launchInWebtop, launchModal: false};
+    return {launchInWebtop: launchInWebtop, launchModal: false, timeout: null};
 }
 
 /**
@@ -48,13 +48,12 @@ var CenterLaunchLink = React.createClass({
         var me = this;
         me.setState({'launchModal': true});
 
-        setTimeout(function(){
-            me.setState({'launchModal': false});
-        }, 10000);
+        me.setState({'timeout' : setTimeout(me.modalConfirmation, 10000)});
     },
 
-    modalConfimation: function(){
+    modalConfirmation: function(){
         this.setState({'launchModal': false});
+        clearTimeout(this.state.timeout);
     },
 
     render: function() {
@@ -64,15 +63,15 @@ var CenterLaunchLink = React.createClass({
         var launchWarning = this.state.launchModal;
         var requirements = this.props.listing.requirements;
         var launchModal = requirements != '' && requirements.toLowerCase() != 'none'
-            ? (<Modal ref="modal" className="LaunchConfirmation" size="small" title="Launch Requirements Notice" onCancel={this.modalConfimation}>
+            ? (<Modal ref="modal" className="LaunchConfirmation" size="small" title="Launch Requirements Notice" onCancel={this.modalConfirmation}>
                   <strong>
                       <p>Please review the requirements below if you have problems launching <b>{this.props.listing.title}</b></p>
                       <br/>
                       <p>{this.props.listing.requirements}</p>
                       <br/>
-                      <p>This dialog box will close automatically after 10 seconds</p>
                   </strong>
-                  <button className="btn btn-danger" onClick={this.modalConfimation}>OK</button>
+                  <p>This dialog box will close automatically after 10 seconds</p>
+                  <button className="btn btn-danger" onClick={this.modalConfirmation}>OK</button>
               </Modal>)
           : null;
 

--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -13,7 +13,7 @@ function getState(profileData) {
     var profile = profileData.currentUser,
         launchInWebtop = profile ? profile.launchInWebtop : false;
 
-    return {launchInWebtop: launchInWebtop, onHidden: true, launchModal: false};
+    return {launchInWebtop: launchInWebtop, launchModal: false};
 }
 
 /**

--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -48,7 +48,7 @@ var CenterLaunchLink = React.createClass({
         var me = this;
         me.setState({'launchModal': true});
 
-        me.setState({'timeout' : setTimeout(me.modalConfirmation, 10000)});
+        me.setState({'timeout' : setTimeout(me.modalConfirmation, 30000)});
     },
 
     modalConfirmation: function(){
@@ -65,12 +65,12 @@ var CenterLaunchLink = React.createClass({
         var launchModal = requirements != '' && requirements.toLowerCase() != 'none'
             ? (<Modal ref="modal" className="LaunchConfirmation" size="small" title="Launch Requirements Notice" onCancel={this.modalConfirmation}>
                   <strong>
-                      <p>Please review the requirements below if you have problems launching <b>{this.props.listing.title}</b></p>
+                      <p>Please review the requirements below if you have problems launching <b>{this.props.listing.title}</b>:</p>
                       <br/>
                       <p>{this.props.listing.requirements}</p>
                       <br/>
                   </strong>
-                  <p>This dialog box will close automatically after 10 seconds</p>
+                  <p>This dialog box will close automatically after 30 seconds.</p>
                   <button className="btn btn-danger" onClick={this.modalConfirmation}>OK</button>
               </Modal>)
           : null;

--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -7,11 +7,13 @@ var SelfStore = require('ozp-react-commons/stores/SelfStore');
 
 var ListingActions = require('../actions/ListingActions');
 
+var Modal = require('ozp-react-commons/components/Modal.jsx');
+
 function getState(profileData) {
     var profile = profileData.currentUser,
         launchInWebtop = profile ? profile.launchInWebtop : false;
 
-    return {launchInWebtop: launchInWebtop};
+    return {launchInWebtop: launchInWebtop, onHidden: true, launchModal: false};
 }
 
 /**
@@ -39,17 +41,49 @@ var CenterLaunchLink = React.createClass({
       });
     },
 
+    launchClick: function(){
+        var listingLaunchFn = ListingActions.launch.bind(null, this.props.listing)
+        listingLaunchFn();
+
+        var me = this;
+        me.setState({'launchModal': true});
+
+        setTimeout(function(){
+            me.setState({'launchModal': false});
+        }, 10000);
+    },
+
+    modalConfimation: function(){
+        this.setState({'launchModal': false});
+    },
+
     render: function() {
-        var listingLaunchFn = ListingActions.launch.bind(null, this.props.listing),
-            { className, ...otherProps } = this.props,
+        var { className, ...otherProps } = this.props,
             linkClassName = className ? className + ' btn' : 'btn';
 
+        var launchWarning = this.state.launchModal;
+        var requirements = this.props.listing.requirements;
+        var launchModal = requirements != '' && requirements.toLowerCase() != 'none'
+          ? (<Modal ref="modal" className="LaunchConfirmation" size="small" title="Launch Requirements Notice" onCancel={this.modalConfimation}>
+            <strong>
+                <p>Please review the requirements below if you have problems launching <b>{this.props.listing.title}</b></p>
+                <br/>
+                <p>{this.props.listing.requirements}</p>
+                <br/>
+                <p>This dialog box will close automatically after 10 seconds</p>
+            </strong>
+            <button className="btn btn-danger" onClick={this.modalConfimation}>OK</button>
+        </Modal>) : null;
 
         return (
-            <button ref="tooltipped" data-toggle="tooltip" data-placement="top" alt="Click to launch this app" title="Launch" { ...otherProps } className={linkClassName}
-                    onClick={listingLaunchFn}>
-                <i className="icon-open-grayDark" /><span className="hidden-span">Launch</span>
-            </button>
+            <div style={{float: 'left'}}>
+              <button ref="tooltipped" data-toggle="tooltip" data-placement="top" alt="Click to launch this app" title="Launch" { ...otherProps } className={linkClassName}
+                      onClick={this.launchClick}>
+                  <i className="icon-open-grayDark" /><span className="hidden-span">Launch</span>
+
+              </button>
+              {launchWarning ? launchModal : null}
+            </div>
         );
     }
 });

--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -76,7 +76,7 @@ var CenterLaunchLink = React.createClass({
           : null;
 
         return (
-            <div style={{float: 'left'}}>
+            <div style={{float: 'left', marginRight: '-1px'}}>
                 <button ref="tooltipped" data-toggle="tooltip" data-placement="top" alt="Click to launch this app" title="Launch" { ...otherProps } className={linkClassName}
                         onClick={this.launchClick}>
                     <i className="icon-open-grayDark" /><span className="hidden-span">Launch</span>

--- a/app/js/services/ListingService.js
+++ b/app/js/services/ListingService.js
@@ -210,6 +210,11 @@ ListingActions.deleteReview.listen(function (listing, review) {
 ListingActions.launch.listen(function (listing) {
     OzpAnalytics.trackEvent('Applications', listing.title, listing.agencyShort);
     window.open(listing.launchUrl);
+/*
+    if(listing.requirements != ''){
+        alert('Note: If you have problems accessing this site, please review the requirements - ' + listing.requirements);
+    }
+*/
 });
 
 ListingActions.save.listen(function (data) {

--- a/app/js/services/ListingService.js
+++ b/app/js/services/ListingService.js
@@ -210,11 +210,6 @@ ListingActions.deleteReview.listen(function (listing, review) {
 ListingActions.launch.listen(function (listing) {
     OzpAnalytics.trackEvent('Applications', listing.title, listing.agencyShort);
     window.open(listing.launchUrl);
-/*
-    if(listing.requirements != ''){
-        alert('Note: If you have problems accessing this site, please review the requirements - ' + listing.requirements);
-    }
-*/
 });
 
 ListingActions.save.listen(function (data) {

--- a/app/styles/_quickview.scss
+++ b/app/styles/_quickview.scss
@@ -117,11 +117,11 @@ ul.list-unstyled.RecentActivity
     border-top: 4px solid #eeeeef;
     height: 156px;
     overflow: hidden;
-    
+
     .carousel, .carousel-wrapper {
         max-height: 89px;
     }
-    
+
     .recommendations-title {
         font-size: 18px;
         line-height: 18px;
@@ -136,7 +136,7 @@ ul.list-unstyled.RecentActivity
         overflow: hidden;
         text-overflow: ellipsis;
     }
-    
+
     .recommendations-tile{
         @extend .quickview-header;
         cursor: pointer;
@@ -384,5 +384,27 @@ ul.list-unstyled.RecentActivity
     }
 }
 
+.LaunchConfirmation {
+    z-index: 1050;
+}
 
+.LaunchConfirmation .modal-dialog {
+  width: 500px;
+  top: 110px;
+}
 
+.LaunchConfirmation .modal-body {
+  padding-top: 20px;
+  padding-left: 50px;
+  padding-right: 50px;
+  padding-bottom: 20px;
+  text-align: center; }
+  .LaunchConfirmation .modal-body strong {
+    font-weight: normal;
+    font-size: 1.3em;
+    display: block;
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .LaunchConfirmation .modal-body .btn {
+    margin-right: 5px;
+    margin-left: 5px; }


### PR DESCRIPTION
Opens a notice after clicking Launch providing guidance to the user if there are requirements in place for using the application.  A 30 second timeout is implemented to reduce the number of clicks needed by a user and should provide an acceptable amount of time for the user to see a page has not loaded, return to AML, and read the notice.

![screenshot from 2017-06-27 16-59-51](https://user-images.githubusercontent.com/21367387/27600148-00730050-5b39-11e7-8f20-4319b711be28.png)


The dialog box will NOT open if the Requirements field for an Application is either empty or None.