### PR TITLE
fix: Changed caption and hint fields from 'demote' to 'remove.'

### DIFF
--- a/app/js/components/management/mall/Stewards.jsx
+++ b/app/js/components/management/mall/Stewards.jsx
@@ -68,7 +68,7 @@ var Stewards = React.createClass({
                 toolbar: {
                     name: 'toolbar',
                     items: [
-                        { type: 'button', id: 'demoteButton', caption: 'Demote', hint: 'Demote a Steward', img: 'icon-delete', disabled: true }
+                        { type: 'button', id: 'demoteButton', caption: 'Remove', hint: 'Remove a user from list of stewards', img: 'icon-delete', disabled: true }
                     ],
                     onClick: function (target, data) {
                         data.onComplete = function(){


### PR DESCRIPTION
Please review:
@mannyrivera2010 
@mleeBoeing 
@blynch11p 
@seenusuvarna 

In Center Settings -> Stewards, where it once said demote now says remove.