### PR TITLE
Sub long cat names

### DIFF
--- a/app/js/components/discovery/Sidebar.jsx
+++ b/app/js/components/discovery/Sidebar.jsx
@@ -87,11 +87,11 @@ var Sidebar = React.createClass({
                 'facet-group-item': true
             });
 
-            var categoryLink = <a className="subscribe" onClick={ (e) => {me.onSubscribeClick(e, category)} } >Subscribe</a>;
+            var categoryLink = <span className="subscribe"> | <a onClick={ (e) => {me.onSubscribeClick(e, category)} } >Subscribe</a></span>;
             if (me.state.categorySubscriptionStore && me.state.categorySubscriptionStore.length > 0) {
                 me.state.categorySubscriptionStore.forEach(function(element) {
                     if (element.entity_description == category.title) {
-                        categoryLink = <a className="subscribe" onClick={ (e) => {me.onUnsubscribeClick(e, category)} }>Unsubscribe</a>;
+                        categoryLink = <span className="subscribe"> | <a onClick={ (e) => {me.onUnsubscribeClick(e, category)} }>Unsubscribe</a></span>;
                     }
                 });
             }

--- a/app/styles/_discovery.scss
+++ b/app/styles/_discovery.scss
@@ -79,7 +79,7 @@
                 }
 
                 > span:first-child {
-                  max-width: 65%;
+                  max-width: 60%;
                   display: inline-block;
                   overflow: hidden;
                   text-overflow: ellipsis;

--- a/app/styles/_discovery.scss
+++ b/app/styles/_discovery.scss
@@ -61,6 +61,9 @@
 
         li {
             border-left: transparent 5px solid;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
 
             i.icon-shopping {
                 @extend .icon-shopping-grayDarker;
@@ -75,12 +78,22 @@
                     @extend .icon-shopping-blueDark;
                 }
 
-                > .subscribe {
+                > span:first-child {
+                  max-width: 65%;
+                  display: inline-block;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                  height: 23px;
+                }
+
+                > span.subscribe {
                     visibility: visible;
-                    float: right;
                     color: gray;
                     font-size: 75%;
                     padding-right: 10px;
+                    right: 0px;
+                    position: absolute;
                 }
             }
 
@@ -100,7 +113,7 @@
                 }
             }
 
-            > .subscribe {
+            > span.subscribe {
                 visibility: hidden;
             }
         }


### PR DESCRIPTION
… subscribe link

Edit a category name or two to make it much longer (Center Settings -> Categories):

Make sure the category names and (un)subscribe links on Center don't interfere with each other.

Also, resize the browser window (max) and shrink it width wise and verify nothing looks 'off'

@mleeBoeing @J-Fid @lsemesky @rkenyon1969 