### PR TITLE
Fix sort by after new category/orginzation/type changes

### DIFF
--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -97,24 +97,29 @@ var Discovery = React.createClass({
         }
     },
 
-    onCategoryChange(categories) {
+    resetSearchState() {
         this._searching = true;
-        this.setState({ categories, currentOffset: 0 });
+        this.setState({currentOffset: 0, orderingText: 'Sort By', ordering: []});
+    },
+
+    onCategoryChange(categories) {
+        this.resetSearchState();
+        this.setState({ categories });
     },
 
     onTagsChange(tags) {
-        this._searching = true;
-        this.setState({ tags, currentOffset: 0 });
+        this.resetSearchState();
+        this.setState({ tags });
     },
 
     onTypeChange(type) {
-        this._searching = true;
-        this.setState({ type, currentOffset: 0 });
+        this.resetSearchState();
+        this.setState({ type });
     },
 
     onOrganizationChange(agency) {
-        this._searching = true;
-        this.setState({ agency, currentOffset: 0 });
+        this.resetSearchState();
+        this.setState({ agency });
     },
 
     onSortChange(order) {


### PR DESCRIPTION
Issue: sort by state does not change or reflect accurately sort order of returned results when clicking on a category from center home:
STR:
On "Center Home" sort "Most Popular" by "Title: Z to A"
Click on "Communication" Category in left navigation
Results: return results are in default state but sort by state is still "Title: Z to A" which does not match order of returned results
Expected Results: sort by state matches order of return results or state defaults to "Sort By"
 
Same happens with filtering on Listing Type or Organizations. The Search box does reset the state of the Sort By menu.

