### PR TITLE
Update url after clicking a Similar Listing

### DIFF
--- a/app/js/components/discovery/RecommendedListingTile.jsx
+++ b/app/js/components/discovery/RecommendedListingTile.jsx
@@ -30,9 +30,10 @@ var RecommendedListingTile = React.createClass({
         }
     },
 
-    loadRecommendation: function (recommendation) {
+    loadRecommendation: function (recommendation, href) {
         OzpAnalytics.trackRecommender(listingMessages['recommender.similar'], recommendation.title);
         CurrentListingStore.loadListing(recommendation.id);
+        //window.history.pushState('','', href);
     },
 
     render: function () {
@@ -58,7 +59,11 @@ var RecommendedListingTile = React.createClass({
 
 
         return (
-            <div className="recommendations-tile" onClick={this.loadRecommendation.bind(this,listing)} >
+            <div className="recommendations-tile" onClick={this.loadRecommendation.bind(this,listing, href)} >
+                <a className="listing-link"  href={ href }>
+                    {/* Empty link - css will make it cover entire <li>*/}
+                    <span className="hidden-span">{listing.title}</span>
+                </a>
                 <div className="quickview-header-info">
                     <img className="listing-icon" alt={`${listing.title} header information`} src={ image } data-fallback="/store/images/types/3" />
                     <h3 className="listing-title" tabIndex="0" title={ title }>{ title }

--- a/app/js/components/discovery/RecommendedListingTile.jsx
+++ b/app/js/components/discovery/RecommendedListingTile.jsx
@@ -30,10 +30,9 @@ var RecommendedListingTile = React.createClass({
         }
     },
 
-    loadRecommendation: function (recommendation, href) {
+    loadRecommendation: function (recommendation) {
         OzpAnalytics.trackRecommender(listingMessages['recommender.similar'], recommendation.title);
         CurrentListingStore.loadListing(recommendation.id);
-        //window.history.pushState('','', href);
     },
 
     render: function () {
@@ -59,7 +58,7 @@ var RecommendedListingTile = React.createClass({
 
 
         return (
-            <div className="recommendations-tile" onClick={this.loadRecommendation.bind(this,listing, href)} >
+            <div className="recommendations-tile" onClick={this.loadRecommendation.bind(this,listing)} >
                 <a className="listing-link"  href={ href }>
                     {/* Empty link - css will make it cover entire <li>*/}
                     <span className="hidden-span">{listing.title}</span>

--- a/app/styles/_quickview.scss
+++ b/app/styles/_quickview.scss
@@ -144,6 +144,16 @@ ul.list-unstyled.RecentActivity
         width: 255px;
         display: inline-block;
 
+        .listing-link {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            right: 0;
+            left: 0;
+
+            z-index: 1;
+        }
+
     }
 
 }


### PR DESCRIPTION
There was also a side-effect of the URL not updating that would make a Similar Listing that was loaded be stuck on the tab (Details/etc) the Quick View was on before loading that Similar Listing.

To test:
Use user bettafish
Prior to pulling branch, open a listing from Center, refresh page, click Details tab, after Similar Listings loads, click a listing to load:
Notice the URL does not change
In some cases, when clicking the tabs in quick view after loading the Similar Listing the tabs will not function as expected (the url will update, but not the display)

Pull the branch, following above steps above while making sure the URL updates as expected after choosing a Similar Listing, and the listing goes to the Overview tab.
Also verify that the tabs in the Similar Listing behave as expected.


@mleeBoeing @lsemesky @rkenyon1969 