### PR TITLE
Sort alphabetically prior to sorting ratings to keep dataset the same…

### DIFF
--- a/app/js/stores/DiscoveryPageStore.js
+++ b/app/js/stores/DiscoveryPageStore.js
@@ -34,7 +34,7 @@ var DiscoveryPageStore = Reflux.createStore({
 
     onStorefrontListingsFetched: function (storefrontListings) {
         _newArrivals = storefrontListings.newArrivals;
-        _mostPopular = storefrontListings.mostPopular;
+        _mostPopular = this.sortRating(storefrontListings.mostPopular,"desc");
         _featured = storefrontListings.featured;
         _recommended = storefrontListings.recommended;
 
@@ -81,6 +81,8 @@ var DiscoveryPageStore = Reflux.createStore({
     },
 
     sortRating(arr, order) {
+        // Sort array alphabetically to keep dataset in the same order each time prior to ordering by ratings
+        arr = this.sortAlphabetically(arr);
         arr.sort(function (a, b) {
             if (a.avgRate == b.avgRate) {
                 return (a.totalVotes > b.totalVotes) ? -1 : 1;


### PR DESCRIPTION
Mainly for sorting most popular -> Ratings: High to Low. This is to keep the listing store sorted based on front end in the beginning. Also, to keep the dataset in the same order each time prior to sorting by ratings.