### PR TITLE
Fix Lo to Hi issue with total ratings

### DIFF
--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -298,6 +298,9 @@ var Discovery = React.createClass({
 
 
     onStoreChange() {
+        if (!this.state.searching) {
+            this.setState({orderingText: 'Sort By'});
+        }
         this.setState(this.getInitialState());
     },
 

--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -39,7 +39,7 @@ var sortOptions = [
     {option: 'Newest', searchParam: '-approved_date'},
     {option: 'Title: A to Z', searchParam: 'title'},
     {option: 'Title: Z to A', searchParam: '-title'},
-    {option: 'Rating: Low to High', searchParam: ['avg_rate', '-total_votes']},
+    {option: 'Rating: Low to High', searchParam: ['avg_rate', 'total_votes']},
     {option: 'Rating: High to Low', searchParam: ['-avg_rate', '-total_votes']}
 ];
 

--- a/app/js/stores/DiscoveryPageStore.js
+++ b/app/js/stores/DiscoveryPageStore.js
@@ -85,15 +85,15 @@ var DiscoveryPageStore = Reflux.createStore({
         arr = this.sortAlphabetically(arr);
         arr.sort(function (a, b) {
             if (a.avgRate == b.avgRate) {
-                return (a.totalVotes > b.totalVotes) ? -1 : 1;
+                return (a.totalVotes < b.totalVotes) ? -1 : 1;
             } else {
-                if (order == "desc") {
-                    return (a.avgRate > b.avgRate) ? -1 : 1;
-                } else {
-                    return (a.avgRate < b.avgRate) ? -1 : 1;
-                }
+                return (a.avgRate < b.avgRate) ? -1 : 1;
             }
         });
+
+        if (order == "desc") {
+            arr.reverse();
+        }
 
         return arr;
     },


### PR DESCRIPTION
Fix sort by issue when doing Ratings -> Low to High. If the ratings were equals, the tie breaker would be the total # reviews (most would show up first). Now it should be the opposite (most total # reviews should show last).