### PR TITLE
Allow description for listing and organization dropdown in center

### DIFF
--- a/app/js/components/discovery/Organizations.jsx
+++ b/app/js/components/discovery/Organizations.jsx
@@ -63,19 +63,22 @@ var Organizations = React.createClass({
     render() {
         var orgCounts = this.state.counts;
         return (
-            <SelectBox className="SelectBox__Organizations col-sm-3 col-xs-4" tabIndex="0" label="Organizations" aria-haspopup="true" onChange={this.onChange} value={this.props.value} multiple>
-                {
-                    this.state.system.organizations.map(
-                        (x) => <option
-                        tabIndex={0}
-                        key={x.id}
-                        value={x.shortName}
-                        tag={JSON.stringify(orgCounts[x.id])}>
-                            {x.shortName}
-                        </option>
-                    )
-                }
-            </SelectBox>
+            <div>
+                <SelectBox className="SelectBox__Organizations col-sm-3 col-xs-4" tabIndex="0" label="Organizations" ariaDescribedBy="orgDescription" aria-haspopup="true" onChange={this.onChange} value={this.props.value} multiple>
+                    {
+                        this.state.system.organizations.map(
+                            (x) => <option
+                            tabIndex={0}
+                            key={x.id}
+                            value={x.shortName}
+                            tag={JSON.stringify(orgCounts[x.id])}>
+                                {x.shortName}
+                            </option>
+                        )
+                    }
+                </SelectBox>
+                <span id="orgDescription" className="ariaTip">Press tab once and use the arrow keys to filter through different organizations</span>
+            </div>
         );
     }
 });

--- a/app/js/components/discovery/Types.jsx
+++ b/app/js/components/discovery/Types.jsx
@@ -18,13 +18,16 @@ var Types = React.createClass({
 
     render() {
         return (
-            <SelectBox className="SelectBox__Types col-sm-3 col-xs-4" tabIndex="0" label="Listing Type" aria-haspopup="true" onChange={this.onChange} value={this.props.value} multiple>
-                {
-                    this.state.system.types.map((x, i) =>
-                        <option tabIndex={0} key={`${x.id}.${i}`} value={x.title}>{x.title}</option>
-                    )
-                }
-            </SelectBox>
+            <div>
+                <SelectBox className="SelectBox__Types col-sm-3 col-xs-4" tabIndex="0" label="Listing Type" ariaDescribedBy="typeDescription" aria-haspopup="true" onChange={this.onChange} value={this.props.value} multiple>
+                    {
+                        this.state.system.types.map((x, i) =>
+                            <option tabIndex={0} key={`${x.id}.${i}`} value={x.title}>{x.title}</option>
+                        )
+                    }
+                </SelectBox>
+                <span id="typeDescription" className="ariaTip">Press tab once and use the arrow keys to filter through different listing types</span>
+            </div>
         );
     }
 });

--- a/app/styles/_discovery.scss
+++ b/app/styles/_discovery.scss
@@ -193,6 +193,10 @@
     }
 }
 
+.ariaTip {
+    display: none;
+}
+
 .shareLink{
     color: $blue-darker;
     font-size: 10pt;


### PR DESCRIPTION
Allow the Type and Organization dropdown menu to have a more descriptive text.

Need to have custom react-select-box to get this to work. Remove existing dependency from node_modules and install the one below
https://github.com/aml-development/react-select-box/pull/3

