### PR TITLE
Separating the frontend storefront calls to use the new endpoints

### DIFF
--- a/app/js/actions/ListingActions.js
+++ b/app/js/actions/ListingActions.js
@@ -10,7 +10,11 @@ var ListingActions = createActions({
     fetchCounts: null,
     fetchAllChangeLogs: null,
     fetchAllChangeLogsByID: null,
-    fetchStorefrontListings: null,
+    fetchStorefrontListings: null, //depricated
+    fetchFeaturedListings: null, 
+    fetchRecentListings: null,
+    fetchMostPopularListings: null,
+    fetchRecommendedListings: null,
 
     fetchById: null,
 

--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -158,7 +158,10 @@ var Discovery = React.createClass({
         //this.listenTo(GlobalListingStore, ListingActions.fetchStorefrontListings);
 
         // fetch data when instantiated
-        ListingActions.fetchStorefrontListings();
+        ListingActions.fetchFeaturedListings();
+        ListingActions.fetchRecentListings();
+        ListingActions.fetchMostPopularListings();
+        ListingActions.fetchRecommendedListings();
 
         if(this.context.getCurrentParams().categories){
           this.setState({initCategories: decodeURIComponent(this.context.getCurrentParams().categories).split('+')});

--- a/app/js/services/ListingService.js
+++ b/app/js/services/ListingService.js
@@ -107,8 +107,24 @@ ListingActions.fetchAllChangeLogs.listen(function (profile, filter) {
         });
 });
 
-ListingActions.fetchStorefrontListings.listen(function() {
+ListingActions.fetchStorefrontListings.listen(function() { //depricated
     ListingApi.getStorefrontListings().then(ListingActions.fetchStorefrontListingsCompleted);
+});
+
+ListingActions.fetchFeaturedListings.listen(function() {
+    ListingApi.getFeaturedListings().then(ListingActions.fetchFeaturedListingsCompleted);
+});
+
+ListingActions.fetchRecentListings.listen(function() {
+    ListingApi.getRecentListings().then(ListingActions.fetchRecentListingsCompleted);
+});
+
+ListingActions.fetchMostPopularListings.listen(function() {
+    ListingApi.getMostPopularListings().then(ListingActions.fetchMostPopularListingsCompleted);
+});
+
+ListingActions.fetchRecommendedListings.listen(function() {
+    ListingApi.getRecommendedListings().then(ListingActions.fetchRecommendedListingsCompleted);
 });
 
 ListingActions.fetchById.listen(function (id) {

--- a/app/js/stores/DiscoveryPageStore.js
+++ b/app/js/stores/DiscoveryPageStore.js
@@ -24,8 +24,17 @@ var DiscoveryPageStore = Reflux.createStore({
     * Update local cache when new data is fetched
     **/
     init: function () {
+        //depricated
         this.listenTo(ListingActions.fetchStorefrontListingsCompleted,
                 this.onStorefrontListingsFetched);
+        this.listenTo(ListingActions.fetchFeaturedListingsCompleted,
+                (listings)=>{_featured = listings; this.trigger();});
+        this.listenTo(ListingActions.fetchMostPopularListingsCompleted,
+                (listings)=>{_mostPopular = this.sortRating(listings,"desc"); this.trigger();});
+        this.listenTo(ListingActions.fetchRecentListingsCompleted,
+                (listings)=>{_newArrivals = listings; this.trigger();});
+        this.listenTo(ListingActions.fetchRecommendedListingsCompleted,
+                (listings)=>{_recommended = listings; this.trigger()});
 
         this.listenTo(ListingActions.searchCompleted, this.onSearchCompleted);
 

--- a/app/js/stores/GlobalListingStore.js
+++ b/app/js/stores/GlobalListingStore.js
@@ -40,11 +40,24 @@ var GlobalListingStore = Reflux.createStore({
     * Update local listingsCache when new data is fetched
     **/
     init: function () {
+        //depricated
         this.listenTo(ListingActions.fetchStorefrontListingsCompleted, function(storefront) {
             updateCache(storefront.featured);
             updateCache(storefront.newArrivals);
             updateCache(storefront.mostPopular);
             updateCache(storefront.recommended);
+        });
+        this.listenTo(ListingActions.fetchFeaturedListingsCompleted, function(listings) {
+            updateCache(listings);
+        });
+        this.listenTo(ListingActions.fetchRecentListingsCompleted, function(listings) {
+            updateCache(listings);
+        });
+        this.listenTo(ListingActions.fetchMostPopularListingsCompleted, function(listings) {
+            updateCache(listings);
+        });
+        this.listenTo(ListingActions.fetchRecommendedListingsCompleted, function(listings) {
+            updateCache(listings);
         });
         this.listenTo(ListingActions.searchCompleted, updateCacheFromPaginatedResponse);
         this.listenTo(ListingActions.fetchAllListingsCompleted, function (filter, response) {

--- a/app/js/webapi/Listing.js
+++ b/app/js/webapi/Listing.js
@@ -289,7 +289,7 @@ var ListingApi = {
     getRecommendedListings: function() {
         return $.getJSON(API_URL + '/api/storefront/recommended/').then(
             resp => {
-                return _.map(resp.recommended, this.recommended);
+                return _.map(resp.recommended, this.newListing);
             });
     },
 

--- a/app/js/webapi/Listing.js
+++ b/app/js/webapi/Listing.js
@@ -255,7 +255,7 @@ var ListingApi = {
         return new Listing(listingData);
     },
 
-    getStorefrontListings: function() {
+    getStorefrontListings: function() { //depricated
         return $.getJSON(API_URL + '/api/storefront/').then(
             resp => ({
                 featured: _.map(resp.featured, this.newListing),
@@ -263,6 +263,34 @@ var ListingApi = {
                 mostPopular: _.map(resp.most_popular, this.newListing),
                 recommended: _.map(resp.recommended, this.newListing)
             }));
+    },
+
+    getFeaturedListings: function() {
+        return $.getJSON(API_URL + '/api/storefront/featured/').then(
+            resp => {
+                return _.map(resp.featured, this.newListing);
+            });
+    },
+
+    getRecentListings: function() {
+        return $.getJSON(API_URL + '/api/storefront/recent/').then(
+            resp => {
+                return _.map(resp.recent, this.newListing);
+            });
+    },
+
+    getMostPopularListings: function() {
+        return $.getJSON(API_URL + '/api/storefront/most_popular/').then(
+            resp => {
+                return _.map(resp.most_popular, this.newListing);
+            });
+    },
+
+    getRecommendedListings: function() {
+        return $.getJSON(API_URL + '/api/storefront/recommended/').then(
+            resp => {
+                return _.map(resp.recommended, this.recommended);
+            });
     },
 
     search: function (options) {


### PR DESCRIPTION
to run locally:
make sure you checkout the master backend branch
make sure you pull the latest into the master backend branch
make dev on backend if needed
make reindex_es on backend if needed

checkout this frontend branch

to test:
open developer tools, the network tab
Make sure that when storefront loads there are no references to 
http://127.0.0.1:8001/api/storefront/

and instead are references to the following endpoints
http://127.0.0.1:8001/api/storefront/featured
http://127.0.0.1:8001/api/storefront/recent
http://127.0.0.1:8001/api/storefront/most_popular 
http://127.0.0.1:8001/api/storefront/recommended

Ensure that recommended recomendations still only appear for the beta users (eg. bettafish)

Ensure that store front, search, and clicking on apps still function