### PR TITLE
Change disclaimer for Categories in Create Listings Page

### DIFF
--- a/app/js/components/createEdit/index.jsx
+++ b/app/js/components/createEdit/index.jsx
@@ -396,7 +396,6 @@ var ListingForm = React.createClass({
                 <TextInput id={f.versionNumber.id} { ...p('versionName') }/>
                 <TextInput id={f.launchUrl.id} { ...decodedUrl }/>
 
-
                 <Toggle toggleId="privateListing"
                     explanation={['This web application/widget is visible to all agencies in the community',
                                     'This web application/widget is only visible to your agency']}

--- a/app/js/components/createEdit/validation/listing.js
+++ b/app/js/components/createEdit/validation/listing.js
@@ -51,7 +51,8 @@ var securityMarking = NonBlankString(200),
     contacts = list(Contact),
     docUrls = list(Resource),
     owners = list(User),
-    atLeastOne = l => l.length > 0;
+    atLeastOne = l => l.length > 0,
+    atLeastOneLessThree = l =>l.length > 0 && l.length <= 3;
 
 function getRequiredContactTypes (contactTypes) {
     return contactTypes.filter(t => t.required).map(t => t.name);
@@ -68,7 +69,7 @@ function ListingFull (requiredContactTypes) {
         securityMarking: securityMarking,
         title: title,
         type: type,
-        categories: subtype(categories, atLeastOne),
+        categories: subtype(categories, atLeastOneLessThree),
         tags: subtype(tags, atLeastOne),
         description: NonBlankString(4000),
         descriptionShort: NonBlankString(100),
@@ -99,7 +100,7 @@ var ListingDraft = struct({
     securityMarking: securityMarking,
     title: title,
     type: type,
-    categories: categories,
+    categories: subtype(categories, atLeastOneLessThree),
     tags: tags,
     description: maybe(StringMax(4000)),
     descriptionShort: maybe(StringMax(100)),


### PR DESCRIPTION
Update disclaimer message on Categories section in Create Listing page. Should show red error when no categories selected and when more than 3 are selected.

Must have the disclaimer branch in ozp-react-commons in your node_modules:
https://github.com/aml-development/ozp-react-commons/pull/88
