### PR TITLE
Allow ability to delete Notification in Center Settings

### DIFF
--- a/app/js/actions/NotificationActions.js
+++ b/app/js/actions/NotificationActions.js
@@ -64,6 +64,12 @@ var NotificationActions = createActions({
       NotificationApi.fetchPast(url, id)
           .then(NotificationActions.fetchPastCompleted)
           .fail(NotificationActions.fetchPastFailed);
+    },
+
+    deleteNotification(notificationId) {
+        NotificationApi.delete(notificationId)
+            .then(NotificationActions.deleteNotificationCompleted)
+            .fail(NotificationActions.deleteNotificationFailed);
     }
 
 });

--- a/app/js/components/management/mall/notifications/ActiveNotification.jsx
+++ b/app/js/components/management/mall/notifications/ActiveNotification.jsx
@@ -6,6 +6,7 @@ var _ = require('../../../../utils/_');
 var _Date = require('ozp-react-commons/components/Date.jsx');
 var Time = require('ozp-react-commons/components/Time.jsx');
 var NotificationActions = require('../../../../actions/NotificationActions.js');
+var { DeleteConfirmation } = require('../../../shared/DeleteConfirmation.jsx');
 
 var ActiveNotification = React.createClass({
     mixins: [React.addons.PureRenderMixin],
@@ -20,6 +21,12 @@ var ActiveNotification = React.createClass({
         }
     },
 
+    getInitialState() {
+        return {
+            deleting: false
+        }
+    },
+
     onStopClick() {
         // The backend complains when you send it listing and author, so send subset
         var subset = _.pick(this.props.notification, ['id', 'expiresDate']);
@@ -28,6 +35,30 @@ var ActiveNotification = React.createClass({
 
     deleteNotification(notificationId) {
         NotificationActions.deleteNotification(notificationId);
+        this.refs.modal.close();
+    },
+
+    isDelete() {
+        this.setState({ deleting: true });
+    },
+
+    closeModal() {
+        sweetAlert({
+            title: "Deletion complete",
+            text: "The notification has been deleted.",
+            type: "info",
+            confirmButtonColor: "#DD6B55",
+            confirmButtonText: "ok",
+            closeOnConfirm: true,
+            html: false
+        });
+    },
+
+    renderDeleteConfirmation(notification) {
+        return (
+            <DeleteConfirmation ref="modal" kind="notification"
+                onHidden={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
+        );
     },
 
     render() {
@@ -42,8 +73,9 @@ var ActiveNotification = React.createClass({
                     <h5 style={{margin: 0, fontWeight: 400}}>{(listing) ? listing.title : 'AppsMall'}</h5>
                     <em>Created: <_Date date={created} /> at <Time date={created} /> / </em>
                     <em>Expires: <_Date date={expiresDate} /> at <Time date={expiresDate} /></em>
-                    <a onClick={() => this.deleteNotification(this.props.notification.id)}><i className="icon-trash-12-blueDarker activeIcon resend" title="Delete Notification"></i></a>
+                    <a onClick={() => this.isDelete()}><i className="icon-trash-12-blueDarker activeIcon resend" title="Delete Notification"></i></a>
                 </div>
+                { this.state.deleting && this.renderDeleteConfirmation(this.props.notification) }
                 <p dangerouslySetInnerHTML={{ __html: message}} />
             </div>
         );

--- a/app/js/components/management/mall/notifications/ActiveNotification.jsx
+++ b/app/js/components/management/mall/notifications/ActiveNotification.jsx
@@ -49,7 +49,7 @@ var ActiveNotification = React.createClass({
     renderDeleteConfirmation(notification) {
         return (
             <DeleteConfirmation ref="modal" kind="notification"
-                onCancel={this.closeModal} onClose={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
+                onCancel={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
         );
     },
 

--- a/app/js/components/management/mall/notifications/ActiveNotification.jsx
+++ b/app/js/components/management/mall/notifications/ActiveNotification.jsx
@@ -42,10 +42,14 @@ var ActiveNotification = React.createClass({
         this.setState({ deleting: true });
     },
 
+    closeModal() {
+        this.setState(this.getInitialState());
+    },
+
     renderDeleteConfirmation(notification) {
         return (
             <DeleteConfirmation ref="modal" kind="notification"
-                onDelete={() =>this.deleteNotification(notification.id)}/>
+                onCancel={this.closeModal} onClose={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
         );
     },
 

--- a/app/js/components/management/mall/notifications/ActiveNotification.jsx
+++ b/app/js/components/management/mall/notifications/ActiveNotification.jsx
@@ -42,22 +42,10 @@ var ActiveNotification = React.createClass({
         this.setState({ deleting: true });
     },
 
-    closeModal() {
-        sweetAlert({
-            title: "Deletion complete",
-            text: "The notification has been deleted.",
-            type: "info",
-            confirmButtonColor: "#DD6B55",
-            confirmButtonText: "ok",
-            closeOnConfirm: true,
-            html: false
-        });
-    },
-
     renderDeleteConfirmation(notification) {
         return (
             <DeleteConfirmation ref="modal" kind="notification"
-                onHidden={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
+                onDelete={() =>this.deleteNotification(notification.id)}/>
         );
     },
 

--- a/app/js/components/management/mall/notifications/ActiveNotification.jsx
+++ b/app/js/components/management/mall/notifications/ActiveNotification.jsx
@@ -26,6 +26,10 @@ var ActiveNotification = React.createClass({
         NotificationActions.expireNotification(subset);
     },
 
+    deleteNotification(notificationId) {
+        NotificationActions.deleteNotification(notificationId);
+    },
+
     render() {
         var { listing, expiresDate, createdDate, message  } = this.props.notification;
         var created = new Date(createdDate);
@@ -38,6 +42,7 @@ var ActiveNotification = React.createClass({
                     <h5 style={{margin: 0, fontWeight: 400}}>{(listing) ? listing.title : 'AppsMall'}</h5>
                     <em>Created: <_Date date={created} /> at <Time date={created} /> / </em>
                     <em>Expires: <_Date date={expiresDate} /> at <Time date={expiresDate} /></em>
+                    <a onClick={() => this.deleteNotification(this.props.notification.id)}><i className="icon-trash-12-blueDarker activeIcon resend" title="Delete Notification"></i></a>
                 </div>
                 <p dangerouslySetInnerHTML={{ __html: message}} />
             </div>

--- a/app/js/components/management/mall/notifications/PastNotification.jsx
+++ b/app/js/components/management/mall/notifications/PastNotification.jsx
@@ -38,10 +38,14 @@ var PastNotification = React.createClass({
         this.setState({ deleting: true });
     },
 
+    closeModal() {
+        this.setState(this.getInitialState());
+    },
+
     renderDeleteConfirmation(notification) {
         return (
             <DeleteConfirmation ref="modal" kind="notification"
-                onDelete={() =>this.deleteNotification(notification.id)}/>
+                onCancel={this.closeModal} onClose={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
         );
     },
 

--- a/app/js/components/management/mall/notifications/PastNotification.jsx
+++ b/app/js/components/management/mall/notifications/PastNotification.jsx
@@ -4,10 +4,11 @@ var React = require('react');
 var _Date = require('ozp-react-commons/components/Date.jsx');
 var Time = require('ozp-react-commons/components/Time.jsx');
 var NotificationActions = require('../../../../actions/NotificationActions.js');
+var { DeleteConfirmation } = require('../../../shared/DeleteConfirmation.jsx');
 
 var PastNotification = React.createClass({
     mixins: [React.addons.PureRenderMixin],
-    
+
     statics: {
         fromArray: function (notifications, id, centerSettings, fn) {
             if (notifications) {
@@ -22,8 +23,38 @@ var PastNotification = React.createClass({
         this.props.fn(message);
     },
 
+    getInitialState() {
+        return {
+            deleting: false
+        }
+    },
+
     deleteNotification(notificationId) {
         NotificationActions.deleteNotification(notificationId);
+        this.refs.modal.close();
+    },
+
+    isDelete() {
+        this.setState({ deleting: true });
+    },
+
+    closeModal() {
+        sweetAlert({
+            title: "Deletion complete",
+            text: "The notification has been deleted.",
+            type: "info",
+            confirmButtonColor: "#DD6B55",
+            confirmButtonText: "ok",
+            closeOnConfirm: true,
+            html: false
+        });
+    },
+
+    renderDeleteConfirmation(notification) {
+        return (
+            <DeleteConfirmation ref="modal" kind="notification"
+                onHidden={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
+        );
     },
 
     render() {
@@ -40,9 +71,10 @@ var PastNotification = React.createClass({
                     <h5 style={{margin: 0, fontWeight: 400}}>{(listing) ? listing.title : 'AppsMall' }</h5>
                     <em>Created: <_Date date={created} /> at <Time date={created} /> / </em>
                     <em>Expired: <_Date date={expiresDate} /> at <Time date={expiresDate} /></em>
-                    <a onClick={() => this.deleteNotification(this.props.notification.id)}><i className="icon-trash-12-blueDarker activeIcon resend" title="Delete Notification"></i></a>
+                    <a onClick={() => this.isDelete()}><i className="icon-trash-12-blueDarker activeIcon resend" title="Delete Notification"></i></a>
                     {resend}
                 </div>
+                { this.state.deleting && this.renderDeleteConfirmation(this.props.notification) }
                 <p dangerouslySetInnerHTML={{ __html: message}} />
             </div>
         );

--- a/app/js/components/management/mall/notifications/PastNotification.jsx
+++ b/app/js/components/management/mall/notifications/PastNotification.jsx
@@ -3,8 +3,11 @@
 var React = require('react');
 var _Date = require('ozp-react-commons/components/Date.jsx');
 var Time = require('ozp-react-commons/components/Time.jsx');
+var NotificationActions = require('../../../../actions/NotificationActions.js');
 
 var PastNotification = React.createClass({
+    mixins: [React.addons.PureRenderMixin],
+    
     statics: {
         fromArray: function (notifications, id, centerSettings, fn) {
             if (notifications) {
@@ -14,9 +17,15 @@ var PastNotification = React.createClass({
             }
         }
     },
+
     resend: function(message){
         this.props.fn(message);
     },
+
+    deleteNotification(notificationId) {
+        NotificationActions.deleteNotification(notificationId);
+    },
+
     render() {
         var { listing, expiresDate, message, createdDate } = this.props.notification;
         var created = new Date(createdDate);
@@ -31,6 +40,7 @@ var PastNotification = React.createClass({
                     <h5 style={{margin: 0, fontWeight: 400}}>{(listing) ? listing.title : 'AppsMall' }</h5>
                     <em>Created: <_Date date={created} /> at <Time date={created} /> / </em>
                     <em>Expired: <_Date date={expiresDate} /> at <Time date={expiresDate} /></em>
+                    <a onClick={() => this.deleteNotification(this.props.notification.id)}><i className="icon-trash-12-blueDarker activeIcon resend" title="Delete Notification"></i></a>
                     {resend}
                 </div>
                 <p dangerouslySetInnerHTML={{ __html: message}} />

--- a/app/js/components/management/mall/notifications/PastNotification.jsx
+++ b/app/js/components/management/mall/notifications/PastNotification.jsx
@@ -38,22 +38,10 @@ var PastNotification = React.createClass({
         this.setState({ deleting: true });
     },
 
-    closeModal() {
-        sweetAlert({
-            title: "Deletion complete",
-            text: "The notification has been deleted.",
-            type: "info",
-            confirmButtonColor: "#DD6B55",
-            confirmButtonText: "ok",
-            closeOnConfirm: true,
-            html: false
-        });
-    },
-
     renderDeleteConfirmation(notification) {
         return (
             <DeleteConfirmation ref="modal" kind="notification"
-                onHidden={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
+                onDelete={() =>this.deleteNotification(notification.id)}/>
         );
     },
 

--- a/app/js/components/management/mall/notifications/PastNotification.jsx
+++ b/app/js/components/management/mall/notifications/PastNotification.jsx
@@ -45,7 +45,7 @@ var PastNotification = React.createClass({
     renderDeleteConfirmation(notification) {
         return (
             <DeleteConfirmation ref="modal" kind="notification"
-                onCancel={this.closeModal} onClose={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
+                onCancel={this.closeModal} onDelete={() =>this.deleteNotification(notification.id)}/>
         );
     },
 

--- a/app/js/components/shared/Crud.jsx
+++ b/app/js/components/shared/Crud.jsx
@@ -192,7 +192,7 @@ var Crud = React.createClass({
 
     renderDeleteConfirmation: function () {
         var kind = this.props.title.toLowerCase();
-        var title = this.props.getDisplayName(this.getSelectedRecord());
+        var title = ' "' + this.props.getDisplayName(this.getSelectedRecord()) + '"';
 
         return (
             <DeleteConfirmation ref="modal" kind={ kind } title={ title }

--- a/app/js/components/shared/DeleteConfirmation.jsx
+++ b/app/js/components/shared/DeleteConfirmation.jsx
@@ -38,7 +38,7 @@ var DeleteConfirmation = React.createClass({
             errorMessage = this.props.errorMessage;
         var content = <div>
         <strong>
-            Are you sure that you would like to delete the {kind} &quot;{title}&quot;?
+            Are you sure that you would like to delete the {kind}{title}?
         </strong>
         <button className="btn btn-default" data-dismiss="modal">Cancel</button>
         <button className="btn btn-danger" onClick={onDelete}>Delete</button></div>;
@@ -112,7 +112,7 @@ var ListingDeleteConfirmation = React.createClass({
         if (!listing) {
             return null;
         }
-        var title = listing.title;
+        var title = ' "' + listing.title + '"';
 
         return (
             <DeleteConfirmation ref="modal" kind="listing" title={title}

--- a/app/js/components/shared/DeleteConfirmation.jsx
+++ b/app/js/components/shared/DeleteConfirmation.jsx
@@ -18,6 +18,8 @@ var DeleteConfirmation = React.createClass({
     propTypes: {
         errorMessage: React.PropTypes.string,
         onHidden: React.PropTypes.func,
+        onCancel: React.PropTypes.func,
+        onClose: React.PropTypes.func,
         onDelete: React.PropTypes.func.isRequired
     },
 
@@ -35,12 +37,14 @@ var DeleteConfirmation = React.createClass({
         var kind = this.props.kind,
             title = this.props.title,
             onDelete = this.props.onDelete,
+            onCancel = this.props.onCancel,
+            onClose = this.props.onClose,
             errorMessage = this.props.errorMessage;
         var content = <div>
         <strong>
             Are you sure that you would like to delete the {kind}{title}?
         </strong>
-        <button className="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button className="btn btn-default" data-dismiss="modal" onClick={onCancel}>Cancel</button>
         <button className="btn btn-danger" onClick={onDelete}>Delete</button></div>;
 
         if (errorMessage) {
@@ -52,7 +56,7 @@ var DeleteConfirmation = React.createClass({
 
         return (
             <Modal ref="modal" className="DeleteConfirmation" size="small" onHidden={this.props.onHidden}>
-                <button className="close corner" data-dismiss="modal"><i className="icon-cross-16"></i></button>
+                <button className="close corner" data-dismiss="modal"><i className="icon-cross-16" onClick={onClose}></i></button>
                 {content}
             </Modal>
         );

--- a/app/js/components/shared/DeleteConfirmation.jsx
+++ b/app/js/components/shared/DeleteConfirmation.jsx
@@ -19,7 +19,6 @@ var DeleteConfirmation = React.createClass({
         errorMessage: React.PropTypes.string,
         onHidden: React.PropTypes.func,
         onCancel: React.PropTypes.func,
-        onClose: React.PropTypes.func,
         onDelete: React.PropTypes.func.isRequired
     },
 
@@ -38,7 +37,6 @@ var DeleteConfirmation = React.createClass({
             title = this.props.title,
             onDelete = this.props.onDelete,
             onCancel = this.props.onCancel,
-            onClose = this.props.onClose,
             errorMessage = this.props.errorMessage;
         var content = <div>
         <strong>
@@ -56,7 +54,6 @@ var DeleteConfirmation = React.createClass({
 
         return (
             <Modal ref="modal" className="DeleteConfirmation" size="small" onHidden={this.props.onHidden}>
-                <button className="close corner" data-dismiss="modal"><i className="icon-cross-16" onClick={onClose}></i></button>
                 {content}
             </Modal>
         );

--- a/app/js/stores/ActiveNotificationStore.js
+++ b/app/js/stores/ActiveNotificationStore.js
@@ -13,6 +13,7 @@ var ActiveNotificationStore = Reflux.createStore({
         this.listenTo(NotificationActions.fetchActiveCompleted, this.fetchActiveCompleted);
         this.listenTo(NotificationActions.createNotificationCompleted, this.onCreateCompleted);
         this.listenTo(NotificationActions.expireNotificationCompleted, this.onExpireCompleted);
+        this.listenTo(NotificationActions.deleteNotificationCompleted, this.onDeleteCompleted);
     },
 
     getNotifications() {
@@ -32,6 +33,11 @@ var ActiveNotificationStore = Reflux.createStore({
 
     onExpireCompleted(notification) {
         _.remove(_notifications.data, { id: notification.id });
+        this.trigger();
+    },
+
+    onDeleteCompleted(id) {
+        _.remove(_notifications.data, { id: id });
         this.trigger();
     }
 

--- a/app/js/stores/PastNotificationStore.js
+++ b/app/js/stores/PastNotificationStore.js
@@ -12,6 +12,7 @@ var resetNotifications = function () {
 
 NotificationActions.createNotificationCompleted.listen(resetNotifications);
 NotificationActions.expireNotificationCompleted.listen(resetNotifications);
+NotificationActions.deleteNotificationCompleted.listen(resetNotifications);
 
 var _notifications;
 
@@ -21,6 +22,7 @@ var PastNotificationStore = Reflux.createStore({
         _notifications = new PaginatedList();
         this.listenTo(NotificationActions.fetchPastCompleted, this.fetchPastCompleted);
         this.listenTo(NotificationActions.expireNotificationCompleted, this.onExpireCompleted);
+        this.listenTo(NotificationActions.deleteNotificationCompleted, this.onDeleteCompleted);
     },
 
     getNotifications() {
@@ -40,6 +42,10 @@ var PastNotificationStore = Reflux.createStore({
 
     onExpireCompleted(notification) {
         _notifications.data.unshift(notification);
+        this.trigger();
+    },
+
+    onDeleteCompleted(id) {
         this.trigger();
     }
 

--- a/app/js/webapi/Notification.js
+++ b/app/js/webapi/Notification.js
@@ -35,6 +35,17 @@ module.exports = {
         }).then((x) => this.parse(humps.camelizeKeys(x)));
     },
 
+    delete(id) {
+        return $.ajax({
+            url: `${API_URL}/api/notification/` + id + '/',
+            type: 'delete',
+            dataType: 'json',
+            contentType: 'application/json'
+        }).then((response) => {
+            return id;
+        });
+    },
+
     fetchActive() {
         return $.getJSON(`${API_URL}/api/notifications/pending/?offset=0&limit=${PAGINATION_MAX}`)
             .then((response) => {


### PR DESCRIPTION
As an admin, I want the ability to delete notifications so that I can manage active and past notification lists.

Acceptance Criteria:
Delete option appears next to notification on Center Settings>Notifications page
When user selects to delete the notification will be permanently deleted