### PR TITLE
Fix the sorting when returning back to storefront

### DIFF
--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -100,6 +100,9 @@ var Discovery = React.createClass({
     resetSearchState() {
         this._searching = true;
         this.setState({currentOffset: 0, orderingText: 'Sort By', ordering: []});
+
+        // Need to reset Most Popular in store after search
+        DiscoveryPageStore.resetMostPopular();
     },
 
     onCategoryChange(categories) {

--- a/app/js/stores/DiscoveryPageStore.js
+++ b/app/js/stores/DiscoveryPageStore.js
@@ -50,6 +50,10 @@ var DiscoveryPageStore = Reflux.createStore({
         this.trigger();
     },
 
+    resetMostPopular: function() {
+        _mostPopular = this.sortRating(_mostPopular,"desc");
+    },
+
     getRecommended: function () {
         return _recommended;
     },


### PR DESCRIPTION
Go to Homepage
Go to Most Popular section ( Sorted by default by most popular apps)
Choose Sort by Z-A 
RESULTS - The apps in Most Popular section are sorted now Z-A
Choose a category filter
RESULTS - The results display all apps by category.  Sort By is defaulted.
Go back to Homepage, Go to Most Popular Section.
RESULTS - The Most Popular Section displays default Sort By state but the actual section is sorted by Z-A.
EXPECTED RESULTS - It should have defaulted back to its original most popular sort by state 