### PR TITLE
Fix bug where apps not reflecting the correct rating in similar listings

### DIFF
--- a/app/js/components/quickview/Recommendations.jsx
+++ b/app/js/components/quickview/Recommendations.jsx
@@ -30,6 +30,12 @@ var QuickViewRecommendations = React.createClass({
         shown: React.PropTypes.bool,
     },
 
+    componentDidUpdate: function(prevProps, prevState) {
+        if (prevProps.listing != this.props.listing) {
+            ListingActions.fetchSimilar(this.props.listing.id);
+        }
+    },
+
     getDefaultProps: function () {
         return {
             shown: false
@@ -38,7 +44,7 @@ var QuickViewRecommendations = React.createClass({
 
     renderSimilar: function () {
 
-         var listing = this.props.listing;
+        var listing = this.props.listing;
         var carouselOptions = {
                 auto: false,
                 scroll: {


### PR DESCRIPTION
Similar listings would not show the correct ratings in the quick view modal. The top left would update however the bottom bar wouldn't update. 

Sign in as bettafish
Go to Air Mail
Go to Air Mail 2 and add a review
Go back to Air Mail and you should see the updated review