### PR TITLE
Notification refactor

### DIFF
--- a/app/js/components/NavBar/index.jsx
+++ b/app/js/components/NavBar/index.jsx
@@ -110,7 +110,7 @@ var NavBar = React.createClass({
                     this.state.showHelp && <HelpModal onHidden={this.onModalHidden} />
                 }
                 {
-                    this.state.showNotifications && <NotificationWindow />
+                    this.state.showNotifications && <NotificationWindow onHidden={this.onModalHidden} />
                 }
             </nav>
         );
@@ -129,10 +129,7 @@ var NavBar = React.createClass({
     },
 
     showNotificationsModal: function () {
-        console.log(this.state.showNotifications)
         this.setState({ showNotifications: true });
-        console.log(this.state.showNotifications)
-        
     },
 
     onModalHidden: function () {

--- a/app/js/components/NavBar/index.jsx
+++ b/app/js/components/NavBar/index.jsx
@@ -3,7 +3,8 @@
 var React = require('react');
 var UserNotificationDropdown = require('ozp-react-commons/components/notification/UserNotificationDropdown.jsx');
 var HelpModal = require('./helpmodal.jsx');
-var NotificationsModal = require('./notificationsmodal.jsx');
+var NotificationsModal = require('ozp-react-commons/components/notification/NotificationsModal.jsx');
+
 var ProfileLink = require('../profile/ProfileLink.jsx');
 var ModalLink = require('../ModalLink.jsx');
 var { HUD_URL, METRICS_URL, WEBTOP_URL, DEVELOPER_RESOURCES_URL} = require('ozp-react-commons/OzoneConfig');
@@ -110,7 +111,7 @@ var NavBar = React.createClass({
                     this.state.showHelp && <HelpModal onHidden={this.onModalHidden} />
                 }
                 {
-                    this.state.showNotifications && <NotificationsModal onHidden={this.onModalHidden} />
+                    this.state.showNotifications && <NotificationsModal onHidden={this.onModalHidden} backRoute={this.backRoute} />
                 }
             </nav>
         );
@@ -134,6 +135,12 @@ var NavBar = React.createClass({
 
     onModalHidden: function () {
         this.setState({ showHelp: false, showNotifications: false });
+    },
+    
+    backRoute: function () {
+        (History.length > 1) ?
+        this.goBack : 
+        this.getActiveRoutePath()
     }
 
 });

--- a/app/js/components/NavBar/index.jsx
+++ b/app/js/components/NavBar/index.jsx
@@ -3,8 +3,7 @@
 var React = require('react');
 var UserNotificationDropdown = require('ozp-react-commons/components/notification/UserNotificationDropdown.jsx');
 var HelpModal = require('./helpmodal.jsx');
-var NotificationsModal = require('ozp-react-commons/components/notification/NotificationsModal.jsx');
-
+var NotificationWindow = require('../notification/NotificationWindow.jsx');
 var ProfileLink = require('../profile/ProfileLink.jsx');
 var ModalLink = require('../ModalLink.jsx');
 var { HUD_URL, METRICS_URL, WEBTOP_URL, DEVELOPER_RESOURCES_URL} = require('ozp-react-commons/OzoneConfig');
@@ -111,7 +110,7 @@ var NavBar = React.createClass({
                     this.state.showHelp && <HelpModal onHidden={this.onModalHidden} />
                 }
                 {
-                    this.state.showNotifications && <NotificationsModal onHidden={this.onModalHidden} backRoute={this.backRoute} />
+                    this.state.showNotifications && <NotificationWindow />
                 }
             </nav>
         );
@@ -130,18 +129,16 @@ var NavBar = React.createClass({
     },
 
     showNotificationsModal: function () {
+        console.log(this.state.showNotifications)
         this.setState({ showNotifications: true });
+        console.log(this.state.showNotifications)
+        
     },
 
     onModalHidden: function () {
         this.setState({ showHelp: false, showNotifications: false });
     },
-    
-    backRoute: function () {
-        (History.length > 1) ?
-        this.goBack : 
-        this.getActiveRoutePath()
-    }
+  
 
 });
 

--- a/app/js/components/app.jsx
+++ b/app/js/components/app.jsx
@@ -11,6 +11,7 @@ var Quickview = require('../components/quickview/index.jsx');
 var CenterProfileWindow = require('./profile/CenterProfileWindow.jsx');
 var CenterContactsWindow = require('./contacts/CenterContactsWindow.jsx');
 var FeedbackModal = require('./management/user/FeedbackModal.jsx');
+var NotificationWindow = require('./notification/NotificationWindow.jsx');
 var { ListingDeleteConfirmation } = require('./shared/DeleteConfirmation.jsx');
 var { ListingPendingDeleteConfirmation } = require('./shared/PendingDeleteConfirmation.jsx');
 var { ListingUndeleteConfirmation } = require('./shared/UndeleteConfirmation.jsx');
@@ -29,7 +30,7 @@ var App = React.createClass({
     },
 
     renderModal: function () {
-        var { listing, profile, contacts, tab, action} = this.getQuery();
+        var { listing, profile, contacts, tab, action, notifications} = this.getQuery();
         if (listing) {
             if (tab) {
                 var preview = action === 'preview';
@@ -53,6 +54,9 @@ var App = React.createClass({
         }
         else if (contacts) {
             return <CenterContactsWindow/>;
+        }
+        else if (notifications) {
+            return <NotificationWindow />
         }
     },
 

--- a/app/js/components/notification/NotificationWindow.jsx
+++ b/app/js/components/notification/NotificationWindow.jsx
@@ -22,9 +22,8 @@ var NotificationWindow = React.createClass({
     },
 
     render: function() {
-        console.log('rendering window')
         return (
-            <NotificationsModal backRoute={this.state.backRoute} />
+            <NotificationsModal backRoute={this.state.backRoute} onHidden={this.props.onHidden}/>
         );
     }
 });

--- a/app/js/components/notification/NotificationWindow.jsx
+++ b/app/js/components/notification/NotificationWindow.jsx
@@ -1,0 +1,32 @@
+var NotificationsModal = require('ozp-react-commons/components/notification/NotificationsModal.jsx');
+var React = require('react');
+var Reflux = require('reflux');
+
+var ActiveStateMixin = require('../../mixins/ActiveStateMixin');
+
+var { Navigation } = require('react-router');
+
+
+/**
+ * A simple wrapper around NotificationModal
+ */
+var NotificationWindow = React.createClass({
+    mixins: [ActiveStateMixin, Navigation],
+
+    getInitialState: function() {
+        return {
+            backRoute: (History.length > 1) ?
+                this.goBack :
+                this.getActiveRoutePath()
+        };
+    },
+
+    render: function() {
+        console.log('rendering window')
+        return (
+            <NotificationsModal backRoute={this.state.backRoute} />
+        );
+    }
+});
+
+module.exports = NotificationWindow;


### PR DESCRIPTION
Requires using ozp-react-commons#notificationRefactor
See tickets 603, 655, 600, 656
Acceptance criteria 603:
That hud and center have the same user experience (I don't think the font colors for the notification sidebar differing is important)
HUD Before:
![image](https://user-images.githubusercontent.com/2533916/29588881-1d32c6a4-8761-11e7-8b4b-4cca4abc5235.png)
 
Center Before: (The version we want all to use)
![image](https://user-images.githubusercontent.com/2533916/29588889-24477dd6-8761-11e7-90fe-2c432d1dd286.png)

Acceptance criteria 655:
STR-
Log on as bigbrother
Share a folder with wsmith
Log on as wsmith
See the notification modal
RESULTS - "bigbrother has shared a the folder with you"
EXPECTED RESULTS - Should say "bigbrother has shared the folder {foldername} with you"

Ticket 600:
 As a developer, I would like to access notifications modal from a link so I can embed the link in email notifications.
Acceptance Criteria:
Hyperlink that will take user to notifications modal: http://localhost:8000/dist/#/home/?notifications=true
The modal should behave as it currently does when clicking "See more" under notifications menu in global navigation

Acceptance criteria 656:
STR - 
Go to a shared folder notification in the notification modal
It will prompt you to Ignore or Add or Remove Notification
Ignore and remove Notification does the same exact thing
RESULTS - get rid of Ignore and keep the Remove Notification to keep consistency throughout the notifications