### PR TITLE
Allow responding to reviews

### DIFF
--- a/app/js/actions/ListingActions.js
+++ b/app/js/actions/ListingActions.js
@@ -11,7 +11,7 @@ var ListingActions = createActions({
     fetchAllChangeLogs: null,
     fetchAllChangeLogsByID: null,
     fetchStorefrontListings: null, //depricated
-    fetchFeaturedListings: null, 
+    fetchFeaturedListings: null,
     fetchRecentListings: null,
     fetchMostPopularListings: null,
     fetchRecommendedListings: null,
@@ -27,6 +27,8 @@ var ListingActions = createActions({
     fetchReviews: null,
     saveReview: null,
     deleteReview: null,
+    saveReviewResponse: null,
+    deleteReviewResponse: null,
 
     fetchSimilar: null,
 

--- a/app/js/components/quickview/reviews/EditReview.jsx
+++ b/app/js/components/quickview/reviews/EditReview.jsx
@@ -90,14 +90,16 @@ var EditReview = React.createClass({
     },
 
     isEditingRateAllowed: function () {
-        var reviewerId = this.state.review.author.id;
-        var userId = this.props.user.id;
+        if (this.state.review.author) {
+            var reviewerId = this.state.review.author.id;
+            var userId = this.props.user.id;
 
-        if (reviewerId === userId){
-          return true;
-        }
-        else{
-          return false;
+            if (reviewerId === userId){
+              return true;
+            }
+            else{
+              return false;
+            }
         }
     },
 

--- a/app/js/components/quickview/reviews/ReviewResponses.jsx
+++ b/app/js/components/quickview/reviews/ReviewResponses.jsx
@@ -1,0 +1,93 @@
+'use strict';
+
+var React = require('react');
+var TimeAgo = require('../../shared/TimeAgo.jsx');
+var SubmitResponse = require('./SubmitResponse.jsx');
+
+var ReviewResponse = React.createClass({
+
+    propTypes: {
+        response: React.PropTypes.object.isRequired,
+        listing: React.PropTypes.object.isRequired,
+        review: React.PropTypes.object,
+        user: React.PropTypes.object.isRequired,
+        reviewId: React.PropTypes.number
+    },
+
+    getInitialState: function() {
+        return {
+            isEditting: false
+        }
+    },
+
+    isEditting: function() {
+        this.setState({
+            isEditting: !this.state.isEditting
+        });
+    },
+
+    onEditComplete: function() {
+        this.setState({
+            isEditting: false
+        });
+    },
+
+    isEditAllowed: function() {
+        var { review, user, listing, response } = this.props;
+
+        return (
+            response.author.id === user.id
+        );
+    },
+
+    render: function() {
+        var {response, user, listing, reviewId, review} = this.props;
+        var time = response.createdDate || "";
+
+        return(
+            <li className="Response">
+                <span className="Review__author">{response.author.displayName}</span>
+                <TimeAgo className="Review__time" time={time} />
+                {this.isEditAllowed() && <i className="icon-pencil" onClick={this.isEditting}></i>}
+                <p className="Review__text">{response.text}</p>
+                { this.state.isEditting && this.isEditAllowed() && <SubmitResponse reviewId={reviewId} review={response} parentReview={review} listing={listing} text={response.text} user={user} responded={this.onEditComplete}/>}
+            </li>
+        )
+    }
+});
+
+var ReviewResponses = React.createClass({
+
+    propTypes: {
+        responses: React.PropTypes.array,
+        listing: React.PropTypes.object.isRequired,
+        review: React.PropTypes.object,
+        user: React.PropTypes.object.isRequired
+    },
+
+    getDefaultProps: function() {
+        return { responses: []};
+    },
+
+    render: function() {
+        return (
+            (this.props.responses && this.props.responses.length > 0) ?
+            <ul className="list-unstyled list-reviews">
+                {this.renderResponses()}
+            </ul> :
+            null
+        )
+    },
+
+    renderResponses: function() {
+        var {responses, user, listing, review} = this.props;
+
+        return this.props.responses.map(function (response) {
+            return <ReviewResponse key={response.id} reviewId={response.id} review={review} response={response} user={ user } listing={ listing } />;
+        });
+    }
+
+});
+
+module.exports = ReviewResponses;
+module.exports.ReviewResponse = ReviewResponse;

--- a/app/js/components/quickview/reviews/SubmitResponse.jsx
+++ b/app/js/components/quickview/reviews/SubmitResponse.jsx
@@ -1,0 +1,63 @@
+'use strict';
+
+var React = require('react');
+var Reflux = require('reflux');
+var ReviewResponse = require('./validation');
+var _ = require('../../../utils/_');
+var ListingActions = require('../../../actions/ListingActions');
+
+var SubmitResponse = React.createClass({
+
+    propTypes: {
+        review: React.PropTypes.object.isRequired,
+        listing: React.PropTypes.object.isRequired,
+        user: React.PropTypes.object,
+        text: React.PropTypes.string.isRequired,
+        reviewId: React.PropTypes.number,
+        parentReview: React.PropTypes.object
+    },
+
+    getDefaultProps: function() {
+        return {
+            text: ''
+        }
+    },
+
+    getInitialState: function () {
+        return _.clone(this.props, 'text');
+    },
+
+    onTextChange: function (val) {
+        this.state.text = val.target.value.substring(0, 4000);
+        this.forceUpdate();
+    },
+
+    onSave: function () {
+        ListingActions.saveReviewResponse(this.props.listing, this.state);
+        this.props.responded();
+    },
+
+    onReset: function () {
+        this.state.text = this.props.text;
+        this.forceUpdate();
+    },
+
+    render: function() {
+        var { rate, text } = this.state;
+        var {review, listing} = this.props;
+        var submitButton = text.length > 0 ? <button className="btn btn-success btn-small" onClick={ this.onSave } >Submit</button> : <button className="btn btn-success btn-small" onClick={ this.onSave } disabled>Submit</button>;
+
+        return (
+            <div>
+                <h6>Reply</h6>
+                <textarea className="response-textarea" ref="text" value={ text } onChange={ this.onTextChange }/>
+                <div>
+                    <button className="btn btn-default btn-small" onClick={ this.onReset }>Reset</button>
+                    {submitButton}
+                </div>
+            </div>
+        );
+    }
+});
+
+module.exports = SubmitResponse;

--- a/app/js/components/quickview/reviews/UserReviews.jsx
+++ b/app/js/components/quickview/reviews/UserReviews.jsx
@@ -5,6 +5,8 @@ var IconRating = require('../../shared/IconRating.jsx');
 var _ = require('../../../utils/_');
 var TimeAgo = require('../../shared/TimeAgo.jsx');
 var OzpAnalytics = require('../../../analytics/ozp-analytics');
+var ReviewResponses = require('./ReviewResponses.jsx');
+var SubmitResponse = require('./SubmitResponse.jsx');
 
 var UserReview = React.createClass({
 
@@ -17,6 +19,12 @@ var UserReview = React.createClass({
         onEdit: React.PropTypes.func.isRequired
     },
 
+    getInitialState: function() {
+        return {
+            isResponding: false
+        }
+    },
+
     isEditAllowed: function () {
         var { review, user, listing } = this.props;
         return (
@@ -26,9 +34,26 @@ var UserReview = React.createClass({
         );
     },
 
+    onResponseCompleted: function() {
+        this.setState({
+            isResponding: false
+        });
+    },
+
+    isRespondAllowed: function() {
+        var {review, user, listing} = this.props;
+    },
+
+    respondToReview: function() {
+        this.setState({
+            isResponding: !this.state.isResponding
+        });
+    },
+
     render: function () {
-        var { review, onEdit } = this.props;
+        var { review, onEdit, listing, user } = this.props;
         var time = review.editedDate || review.createdDate || "";
+
         return (
             <li className="Review">
                 <IconRating currentRating = { review.rate } viewOnly={true} />
@@ -38,7 +63,10 @@ var UserReview = React.createClass({
                     this.isEditAllowed() &&
                         <i className="icon-pencil" onClick={ _.partial(onEdit, review) }></i>
                 }
+                <i className="icon-feedback-12-grayDark" onClick={this.respondToReview}></i>
                 <p className="Review__text">{ review.text }</p>
+                { this.state.isResponding && <SubmitResponse review={review} listing={listing} responded={this.onResponseCompleted}/> }
+                <ReviewResponses responses={review.reviewResponses} listing={listing} user={user} review={review}/>
             </li>
         );
     }

--- a/app/js/components/quickview/reviews/index.jsx
+++ b/app/js/components/quickview/reviews/index.jsx
@@ -73,6 +73,7 @@ var ReviewsTab = React.createClass({
     getState: function () {
         var currentUser = SelfStore.getDefaultData().currentUser;
         var reviews = CurrentListingStore.getReviews();
+
         if (!reviews) {
             return {
                 reviews: reviews,

--- a/app/js/services/ListingService.js
+++ b/app/js/services/ListingService.js
@@ -223,6 +223,19 @@ ListingActions.deleteReview.listen(function (listing, review) {
         .fail(_.partial(ListingActions.deleteReviewFailed, listing, review));
 });
 
+ListingActions.saveReviewResponse.listen(function (listing, review) {
+    ListingApi.saveReviewResponse(listing.id, review)
+        .then(function (response) {
+            ListingActions.fetchById(listing.id);
+            ListingActions.fetchReviews(listing);
+            ListingActions.saveReviewResponseCompleted(listing, response);
+            OzpAnalytics.trackListingReview(listing.title, listing.agencyShort);
+        })
+        .fail(function(response) {
+            ListingActions.saveReviewResponseFailed(response);
+        });
+});
+
 ListingActions.launch.listen(function (listing) {
     OzpAnalytics.trackEvent('Applications', listing.title, listing.agencyShort);
     window.open(listing.launchUrl);

--- a/app/js/stores/CurrentListingStore.js
+++ b/app/js/stores/CurrentListingStore.js
@@ -123,9 +123,9 @@ var CurrentListingStore = createStore({
         Object.assign({}, CreateEditActions, {
             systemUpdated: SystemStore,
             cacheUpdated: GlobalListingStore,
-            similarUpdated: ListingActions.fetchSimilarCompleted
+            similarUpdated: ListingActions.fetchSimilarCompleted,
         }),
-        { profileUpdate: SelfStore }
+        { profileUpdate: SelfStore, saveResponseFailed: ListingActions.saveReviewResponseFailed }
     ],
 
     currentUser: null,
@@ -153,7 +153,6 @@ var CurrentListingStore = createStore({
     },
 
     onCacheUpdated: function () {
-
         if (_listingId) {
             var newListing = GlobalListingStore.getById(_listingId);
             if(newListing){
@@ -164,6 +163,27 @@ var CurrentListingStore = createStore({
 
     onSimilarUpdated: function (){
         this.trigger();
+    },
+
+    onSaveResponseFailed: function(error) {
+        var errorMessage = "Try again later.";
+        
+        if (error.status == 400) {
+            errorMessage = "Cannot create duplicate review";
+        } else
+            if (error.status == 403) {
+                errorMessage = "Permission Denied";
+            }
+
+        sweetAlert({
+            title: "Error",
+            text: errorMessage,
+            type: "error",
+            confirmButtonColor: "#DD6B55",
+            confirmButtonText: "ok",
+            closeOnConfirm: true,
+            html: false
+        });
     },
 
     onProfileUpdate: function(profileData) {

--- a/app/js/webapi/Listing.js
+++ b/app/js/webapi/Listing.js
@@ -389,11 +389,13 @@ var ListingApi = {
         if (review.id) {
             method = 'PUT';
             url += `${review.id}/`;
+            review.author = undefined;
         }
         // default rate to 1 if not specified
         if (!review.rate) {
             review.rate = 1;
         }
+        review.listing= listingId;
 
         return $.ajax({
             type: method,
@@ -408,6 +410,33 @@ var ListingApi = {
         return $.ajax({
             type: 'DELETE',
             url: `${API_URL}/api/listing/${listingId}/review/${reviewId}/`,
+            dataType: 'json',
+            contentType: 'application/json'
+        });
+    },
+
+    saveReviewResponse: function (parentId, review) {
+        var url = `${API_URL}/api/listing/${review.listing.id}/review/`,
+            method = 'POST';
+
+        // default rate to 1 if not specified
+        if (!review.rate) {
+            review.rate = 1;
+        }
+
+        review.review_parent = review.review.id;
+        review.listing = review.listing.id;
+
+        if (review.parentReview) {
+            method = 'PUT';
+            url += `${review.reviewId}/`;
+            review.review_parent = review.parentReview.id;
+        }
+
+        return $.ajax({
+            type: method,
+            url: url,
+            data: JSON.stringify(review),
             dataType: 'json',
             contentType: 'application/json'
         });

--- a/app/styles/_quickview.scss
+++ b/app/styles/_quickview.scss
@@ -91,6 +91,10 @@ $quickview-nav-tabs-height: 42px;
             @extend .icon-pencil-blueDark;
         }
     }
+
+    i.icon-share-alt {
+        @extend .icon-share-alt;
+    }
 }
 
 ul.list-unstyled.RecentActivity
@@ -459,6 +463,11 @@ ul.list-unstyled.RecentActivity
         margin-top: 3px;
         cursor: pointer;
     }
+
+    .icon-feedback-12-grayDark {
+        cursor: pointer;
+        left: 5px;
+    }
 }
 
 .SubmitReview__Rating {
@@ -470,4 +479,25 @@ ul.list-unstyled.RecentActivity
         margin-left: 6px;
         color: $link-color;
     }
+}
+
+.Response {
+    background: #eeeeef;
+    border-left: solid 1px black;
+    margin-top: 5px;
+    padding: 5px 5px 5px 15px;
+}
+
+.list-unstyled.list-reviews ul {
+    margin-left: 30px;
+}
+
+.response-textarea {
+    padding: $table-cell-padding;
+    resize: none;
+    margin: 0 0 10px 0;
+    width: 100%;
+    height: 4em;
+    display: block;
+    font-size: 12px;
 }


### PR DESCRIPTION
Allow the ability to respond to reviews

- Users should be able to respond to reviews by clicking the chat bubble icon next to the edit icon
- Users can only respond to their own original review multiple times.
- Users can only edit reviews if the user is editing their own response. Otherwise, the edit icon will not show in the first place
- Reset button
    - If creating a new review response, reset button will clear out the text box.
    - If editing an existing response, reset button will revert back the text box to original review response text
- Once you click submit, the text box should automatically remove itself.
- To close the text box, click on the chat bubble icon again.
- Review response text should update automatically if edited.
- Review responses should not reorder upon edit. Should be sorted by created date.
- You cannot submit a response if there are 0 characters in the text area. Submit button is disabled.