### PR TITLE
feat(delete): Allow admin and org stewards to delete without pending …

### DIFF
--- a/app/js/components/createEdit/index.jsx
+++ b/app/js/components/createEdit/index.jsx
@@ -819,6 +819,7 @@ var CreateEditPage = React.createClass({
             action: 'undelete'
         });
 
+
         var header = (
             <div className="CreateEdit__titlebar">
                 <div className="btn-toolbar" role="group">
@@ -837,14 +838,14 @@ var CreateEditPage = React.createClass({
                             </button>
                         }
                         {
-                            (showDelete && inProgress) &&
+                            (showDelete && (currentUser.isAdmin() || currentUser.isOrgSteward(listing.agencyShort))) &&
                             <a href={deleteHref} className="btn btn-default tool delete-button">
                                 <span className="create-edit-button">Delete</span>
                                 <i className="icon-trash-grayDark"></i>
                             </a>
                         }
                         {
-                            showDelete && (_.contains(owners, currentUser.username) || currentUser.isAdmin()) && !showUndelete && !inProgress &&
+                            showDelete && (_.contains(owners, currentUser.username) && !(currentUser.isAdmin() || currentUser.isOrgSteward(listing.agencyShort))) && !showUndelete && !inProgress &&
                             <a href={pendDeleteHref} className="btn btn-default tool pendDelete-button">
                                 <span className="create-edit-button">Pend for Delete</span>
                                 <i className="icon-trash-grayDark"></i>

--- a/app/js/components/listing/ListingTile.jsx
+++ b/app/js/components/listing/ListingTile.jsx
@@ -53,7 +53,7 @@ var ActionMenu = React.createClass({
 
         switch (approvalStatus) {
             case 'APPROVED':
-                if(currentUser.isAdmin()){
+                if(currentUser.isAdmin() || currentUser.isOrgSteward(listing.agencyShort)){
                   links = [edit, view, del];
                 }
                 else{
@@ -61,7 +61,7 @@ var ActionMenu = React.createClass({
                 }
                 break;
             case 'APPROVED_ORG':
-                if(currentUser.isAdmin()){
+                if(currentUser.isAdmin() || currentUser.isOrgSteward(listing.agencyShort)){
                   links = [edit, view, del];
                 }
                 else{
@@ -69,7 +69,7 @@ var ActionMenu = React.createClass({
                 }
                 break;
             case 'PENDING':
-                if(currentUser.isAdmin()){
+                if(currentUser.isAdmin() || currentUser.isOrgSteward(listing.agencyShort)){
                   links = [edit, view, del];
                 }
                 else{
@@ -77,7 +77,7 @@ var ActionMenu = React.createClass({
                 }
                 break;
             case 'REJECTED':
-                if(currentUser.isAdmin()){
+                if(currentUser.isAdmin() || currentUser.isOrgSteward(listing.agencyShort)){
                   links = [edit, view, del];
                 }
                 else{
@@ -88,7 +88,7 @@ var ActionMenu = React.createClass({
                 links = [];
                 break;
             case 'PENDING_DELETION':
-                if(currentUser.isAdmin()){
+                if(currentUser.isAdmin() || currentUser.isOrgSteward(listing.agencyShort)){
                   links = [edit, view, del];
                 }
                 else{
@@ -98,7 +98,7 @@ var ActionMenu = React.createClass({
             case 'DRAFT':
                 /* falls through */
             default:
-                links = [edit, preview, del];
+                links = [edit, preview, pendingDelete];
         }
 
         //use hidden checkbox to manage menu toggle state

--- a/app/js/components/management/OrgListings/index.jsx
+++ b/app/js/components/management/OrgListings/index.jsx
@@ -23,6 +23,7 @@ var OrgListings = React.createClass({
     mixins: [
         SystemStateMixin,
         ActiveStateMixin,
+        UserRoleMixin.OrgSteward,
     ],
 
     getInitialState: function () {

--- a/app/js/components/management/OrgListings/index.jsx
+++ b/app/js/components/management/OrgListings/index.jsx
@@ -23,7 +23,6 @@ var OrgListings = React.createClass({
     mixins: [
         SystemStateMixin,
         ActiveStateMixin,
-        UserRoleMixin.OrgSteward,
     ],
 
     getInitialState: function () {

--- a/app/js/components/shared/DeleteConfirmation.jsx
+++ b/app/js/components/shared/DeleteConfirmation.jsx
@@ -135,7 +135,19 @@ var ListingDeleteConfirmation = React.createClass({
     },
 
     onHidden: function () {
-        this.transitionTo(this.getActiveRoutePath(), {listingId: this.state.listing.id});
+        if(this.getActiveRoute().name ==='org-listings'){
+          var url = document.URL
+          var urlSplit = url.split("?");
+          location.replace(urlSplit[0])
+        }
+        else if (this.getActiveRoute().name === 'edit'){
+          url = document.URL
+          urlSplit = url.split("?");
+          location.replace(urlSplit[0])
+        }
+        else{
+          this.transitionTo('my-listings');
+        }
     },
 
     onDelete: function () {

--- a/app/js/services/ListingService.js
+++ b/app/js/services/ListingService.js
@@ -344,7 +344,7 @@ ListingActions.deleteListing.listen(function (listing) {
     listing.approvalStatus = 'DELETED';
     ListingApi.del(listing.id)
         .then(ListingActions.deleteListingCompleted.bind(null, listing))
-        .then(ListingActions.listingChangeCompleted(listing))
+        .then(ListingActions.listingChangeCompleted)
         .fail(ListingActions.deleteListingFailed);
 
 });


### PR DESCRIPTION
**AMLNG-315**

Right now the app is inconsistent with the way admins and org stewards delete apps. On some screens they are forced through the pending deletion workflow process and other screens ( Listing Management View) they can delete without going through the pending deletion process.
 
Acceptance Criteria:
Admins and Org Stewards don't need to go through the Pending Deletion Workflow.
Only App Owners need an approval/rejection from either Org Steward/Admin before an App Listing is deleted.



@blynch11p @cwilliams2017 @flesher1 @lsemesky @mannyrivera2010 @rkenyon1969 @skhtet @tdressel 