### PR TITLE
JIRA-750: Fixing the style so the private icon does not overlap

### DIFF
--- a/app/js/components/quickview/Header.jsx
+++ b/app/js/components/quickview/Header.jsx
@@ -31,9 +31,8 @@ var QuickviewHeader = React.createClass({
         var agencyShort = listing.agencyShort;
         var totalVotes = listing.totalVotes;
         var lockStyle = {
-            position: 'absolute',
-            left: '4px',
-            top: '4px'
+            left: '6px',
+            top: '2px'
         };
         var labelStyle = {
             paddingLeft: '10px'


### PR DESCRIPTION
To test:

Prior to pulling branch, log in to Center using obrien.
Find a Listing under the Minipax org (ex: Wolf Finder)
Open the listing and click the edit button.
Scroll down to the "Private Listing" section and enable the listing as private.
Click Save.
Return to Center, find the Minipax listing that was edited, open the listing, and see that the Lock icon is overlapping the Minipax text.

Pull this branch.
Restart center server
Refresh the browser.
The icon should no longer be overlapping the text.