### PR TITLE
feat(feedback): allow ability to remomve feedback when un-toggled

### DIFF
--- a/app/js/actions/ListingActions.js
+++ b/app/js/actions/ListingActions.js
@@ -46,7 +46,8 @@ var ListingActions = createActions({
     pendingDelete: null,
     approveDelete: null,
     undelete: null,
-    giveFeedback: null
+    giveFeedback: null,
+    deleteFeedback: null
 });
 
 ListingActions.listingChangeCompleted = Reflux.createAction();

--- a/app/js/components/FeedbackButton.jsx
+++ b/app/js/components/FeedbackButton.jsx
@@ -1,7 +1,6 @@
 'use strict';
 
 var React = require('react');
-var ListingActions = require('../actions/ListingActions');
 var OzpAnalytics = require('../analytics/ozp-analytics');
 
 var FeedbackButton = React.createClass({

--- a/app/js/components/discovery/RecommendedListingTileStorefront.jsx
+++ b/app/js/components/discovery/RecommendedListingTileStorefront.jsx
@@ -96,17 +96,19 @@ var RecommendedListingTileStorefront = React.createClass({
         );
     },
 
-    giveFeedback: function(thumbs) {
+    giveFeedback : function(thumbs) {
         if (thumbs == 1) {
-            this.setState({
-                positiveToggled: true,
-                negativeToggled: false
-            });
+            if (this.state.positiveToggled) {
+                this.removeFeedback(thumbs);
+                return;
+            }
+            this.setState({positiveToggled: true, negativeToggled: false});
         } else {
-            this.setState({
-                positiveToggled: false,
-                negativeToggled: true
-            });
+            if (this.state.negativeToggled) {
+                this.removeFeedback(thumbs);
+                return;
+            }
+            this.setState({positiveToggled: false, negativeToggled: true});
         }
 
         var feedback = thumbs == 1
@@ -114,6 +116,18 @@ var RecommendedListingTileStorefront = React.createClass({
             : 'Negative';
         OzpAnalytics.trackFeedback(feedback, this.props.listing.title);
         ListingActions.giveFeedback(this.props.listing.id, thumbs);
+    },
+
+    removeFeedback : function(thumbs) {
+        OzpAnalytics.trackFeedback('Remove feedback', this.props.listing.title);
+
+        if (thumbs == 1) {
+            this.setState({positiveToggled: false});
+            ListingActions.deleteFeedback(this.props.listing.id);
+        } else {
+            this.setState({negativeToggled: false});
+            ListingActions.deleteFeedback(this.props.listing.id);
+        }
     },
 
     renderActions: function () {

--- a/app/js/services/ListingService.js
+++ b/app/js/services/ListingService.js
@@ -346,7 +346,6 @@ ListingActions.deleteListing.listen(function (listing) {
         .then(ListingActions.deleteListingCompleted.bind(null, listing))
         .then(ListingActions.listingChangeCompleted)
         .fail(ListingActions.deleteListingFailed);
-
 });
 
 ListingActions.giveFeedback.listen(function (listing, thumbs) {
@@ -355,6 +354,14 @@ ListingActions.giveFeedback.listen(function (listing, thumbs) {
             ListingActions.giveFeedbackCompleted(listing.id, thumbs);
         })
         .fail(ListingActions.giveFeedbackFailed);
+});
+
+ListingActions.deleteFeedback.listen(function (listing) {
+    ListingApi.deleteFeedback(listing)
+        .then(function (response) {
+            ListingActions.deleteFeedbackCompleted(listing.id);
+        })
+        .fail(ListingActions.deleteFeedbackFailed);
 });
 
 ListingActions.setFeatured.listen(updateListingProperty.bind(null, 'isFeatured'));

--- a/app/js/stores/DiscoveryPageStore.js
+++ b/app/js/stores/DiscoveryPageStore.js
@@ -37,6 +37,7 @@ var DiscoveryPageStore = Reflux.createStore({
                 (listings)=>{_recommended = listings; this.trigger()});
         this.listenTo(ListingActions.searchCompleted, this.onSearchCompleted);
         this.listenTo(ListingActions.giveFeedbackCompleted, this.giveFeedbackCompleted);
+        this.listenTo(ListingActions.deleteFeedbackCompleted, this.giveFeedbackCompleted);
 
         this.listenTo(ListingActions.deleteListingCompleted, this.removeListing)
     },

--- a/app/js/webapi/Listing.js
+++ b/app/js/webapi/Listing.js
@@ -516,6 +516,14 @@ var ListingApi = {
             dataType: 'json',
             contentType: 'application/json'
         });
+    },
+
+    deleteFeedback: function(id) {
+        return $.ajax({
+            type: 'DELETE',
+            url: API_URL + '/api/listing/' + id + '/feedback/' + id + '/',
+            contentType: 'application/json'
+        });
     }
 };
 


### PR DESCRIPTION
Need backend: https://github.com/aml-development/ozp-backend/pull/372

If user clicks selected thumb, the feedback will be deleted
If user clicks selected thumb, the feedback button will be undone