### PR TITLE
fix(listing_loading): update loading a listing to prevent tabs from b…

### DIFF
--- a/app/js/components/quickview/index.jsx
+++ b/app/js/components/quickview/index.jsx
@@ -148,8 +148,8 @@ var Quickview = React.createClass({
         return (
             <Modal ref="modal" className="quickview" onShown={this.onShown} onHidden={this.onHidden} tabIndex="0">
                 {
-                    !listing ?
-                        <p>Loading...</p> :
+                    !listing || !listing.title ?
+                        <h1 className="quickview-header listing-title">Loading...<span className="icon-loader-36 loader loader-animate"></span></h1> :
                         [
                             <Header { ...headerProps }  key="header"></Header>,
                             <div className="tabs-container" key="tabs-container">

--- a/app/js/components/quickview/index.jsx
+++ b/app/js/components/quickview/index.jsx
@@ -149,7 +149,7 @@ var Quickview = React.createClass({
             <Modal ref="modal" className="quickview" onShown={this.onShown} onHidden={this.onHidden} tabIndex="0">
                 {
                     !listing || !listing.title ?
-                        <h1 className="quickview-header listing-title">Loading...<span className="icon-loader-36 loader loader-animate"></span></h1> :
+                        <h1 style={{'height': '550px'}} className="quickview-header listing-title">Loading...<span className="icon-loader-36 loader loader-animate"></span></h1> :
                         [
                             <Header { ...headerProps }  key="header"></Header>,
                             <div className="tabs-container" key="tabs-container">


### PR DESCRIPTION
…eing visible before they can be clicked

JIRA-789

The issue was that before a listing loaded, the user could click the Administration tab, which would close the listing.

This was a side effect of trying to show the listing before it was loaded.

There's an additional check in place that the listing is available (listing.title).

The styling of the loading has also been update to include the new loading icon.


To test:
Load a listing from Center, and make sure the dialog shows 'loading' and not tabs before the listing is loaded.
Refresh the page to verify the loading message displays.
Also, create a listing from Create/Edit, Save, and view the preview to verify the preview works.

