### PR TITLE
JIRA 745 - modifying center setting notifications to have a type field

### DIFF
--- a/app/js/components/management/mall/notifications/CreateNotification.jsx
+++ b/app/js/components/management/mall/notifications/CreateNotification.jsx
@@ -23,7 +23,9 @@ var CreateNotification = React.createClass({
             hours: _.range(0, 24).map((x) => {
                 return x < 10 ? `0${x}` : `${x}`;
             }),
-            minutes: ['00', '15', '30', '45', '59']
+            minutes: ['00', '15', '30', '45', '59'],
+            types: [{key: 'System', value: 'System'},
+                    {key: 'StewardAppNotification', value: 'Update Request'}]
         };
     },
 
@@ -33,7 +35,8 @@ var CreateNotification = React.createClass({
             date: null,
             message: '',
             hour: '00',
-            minute: '00'
+            minute: '00',
+            type: 'System'
         };
     },
 
@@ -46,13 +49,7 @@ var CreateNotification = React.createClass({
             event.preventDefault();
         }
 
-        this.setState({
-            uuid: uuid(),
-            date: null,
-            message: '',
-            hour: '00',
-            minute: '00'
-        });
+        this.setState(this.getInitialState());
 
         this.props.fn('');
     },
@@ -66,16 +63,25 @@ var CreateNotification = React.createClass({
         this.setState({message: value.substring(0, 600)});
     },
 
+    onTypeChange(event) {
+        var { value } = event.target;
+        if (value === 'StewardAppNotification')
+            this.setState({type: value, message:'Please review your agency\'s apps and make sure their information is up to date'});
+        else
+            this.setState({type: value, message: ''});
+    },
+
     onSend(event) {
         event.preventDefault();
-        var { message, date, hour, minute } = this.state;
+        var { message, date, hour, minute, type} = this.state;
         var expiresDate = new Date(
             Date.UTC(date.year(), date.month(), date.date(), parseInt(hour, 10), parseInt(minute, 10))
         );
 
         NotificationActions.createNotification(this.state.uuid, {
             expiresDate: expiresDate,
-            message: message
+            message: message,
+            notificationType: type
         });
     },
 
@@ -93,7 +99,15 @@ var CreateNotification = React.createClass({
                 <h4 style={{marginTop: 0}}>Send a Notification</h4>
                 <form>
                     <div className="row">
-                        <div className="col-md-6">
+                        <div className="col-xs-6 col-md-4" style={{paddingRight: '0px'}}>
+                            <div className="form-group">
+                                <label>Type</label>
+                                <div>
+                                    <Select ref="type" name="type" options={ this.props.types } onChange={this.onTypeChange} />
+                                </div>
+                            </div>
+                        </div>
+                        <div className="col-xs-4 col-md-4" style={{paddingRight: '0px'}}>
                             <div className="form-group">
                                 <label htmlFor="notification-expires-time">Expires On</label>
                                 <DatePicker
@@ -105,7 +119,7 @@ var CreateNotification = React.createClass({
                                 />
                             </div>
                         </div>
-                        <div className="col-md-6">
+                        <div className="col-xs-2 col-md-4" style={{paddingRight: '0px'}}>
                             <div className="form-group">
                                 <label>Expires At (Z)</label>
                                 <div>
@@ -114,6 +128,7 @@ var CreateNotification = React.createClass({
                                 </div>
                             </div>
                         </div>
+                        
                     </div>
                     <div className="form-group">
                         <label htmlFor="notification-message">Notification text</label>

--- a/app/js/components/shared/Select.jsx
+++ b/app/js/components/shared/Select.jsx
@@ -11,7 +11,11 @@ var Select = React.createClass({
 
     _renderOptions() {
         return this.props.options.map(function (value) {
-            return <option key={value} value={value}>{value}</option>;
+                    // if the array has objects with key values
+            if(value.key)
+                return <option key={value.key} value={value.key}>{value.value}</option>;
+            else
+                return <option key={value} value={value}>{value}</option>;
         });
     },
 

--- a/app/styles/management/_notifications.scss
+++ b/app/styles/management/_notifications.scss
@@ -31,11 +31,14 @@ position: relative;
 }
 
 .CreateNotification {
+    select {
+        height: 34px;   
+        width: 100%;     
+    }
     select[name="hour"],
     select[name="minute"] {
         display: inline-block;
         width: auto;
         margin-right: 5px;
-        height: 34px;
     }
 }


### PR DESCRIPTION
@aml-development/ozp-backend-team 
Requires 
- ozp-react-commons branch orgstewardNotifications https://github.com/aml-development/ozp-react-commons/pull/105
- ozp-backend branch orgstewardNotification (no s at the end) https://github.com/aml-development/ozp-backend/pull/375

Use Case:
- An admin has the ability to send out a notification to all Content Stewards, notifying them to review their org's Listings and make any necessary changes.
- Content Steward updates Listing as needed via Create New Listing Form (the usual means of updating listings)
- Content Steward and listing owner(s) are notified when listing has been updated and approved

Acceptance Criteria:
- Only admins can send notifications to content stewards
- All content stewards receive the notification to update their apps
- Only content stewards receive the "update app" notification type
- Content stewards can click on a link in the in-site notification to go to the same Listing Management Recent Activity tab. (I chose this tab because all org stewards will have it and they can easily go to published listings from overview list on the left. They can also see which ones have been updated recently)
- The system notification type still functions as before there was no "Type" dropdown

To test:
As bigbrother, 

1. Go to Center Settings (from the dropdown menu)
2. Go to the Notifications Tab
3. Select the Update Request type
4. See that the Notification text is populated with a default message (you can change this message if you like)
5. Set expires on date
6. Press send

Login as david, julia, obrien and wsmith to make sure that they have received the message and that it has the link as detailed in acceptance criteria

bigbrother should not receive the notification
hodor should not receive the notification
jones should not receive the notification
