### PR TITLE
 feat(activity log): add reviews to activity log

### DIFF
--- a/app/js/components/management/user/RecentActivity.jsx
+++ b/app/js/components/management/user/RecentActivity.jsx
@@ -67,6 +67,7 @@ var RecentActivity = React.createClass({
                 'DISABLED' : 'View',
                 'CREATED' : 'View Draft',
                 'APPROVED_ORG' : 'Review Listing',
+                'REVIEWED' : 'View',
                 'REVIEW_EDITED' : 'View',
                 'REVIEW_DELETED' : 'View',
                 'PENDING_DELETION' : 'View'

--- a/app/js/components/management/user/RecentActivity.jsx
+++ b/app/js/components/management/user/RecentActivity.jsx
@@ -78,6 +78,13 @@ var RecentActivity = React.createClass({
                 action: 'view',
                 tab: 'overview'
             });
+            if (changeLog.action === "REVIEWED" || changeLog.action === "REVIEW_EDITED"){
+                href = this.makeHref(this.getActiveRoutePath(), this.getParams(), {
+                    listing: changeLog.listing.id,
+                    action: 'view',
+                    tab: 'reviews'
+                });
+            }
 
             if (!this.state.currentUser.isAdmin()) {
                 linkMap.APPROVED_ORG = 'View';

--- a/app/js/components/shared/ChangeLog.jsx
+++ b/app/js/components/shared/ChangeLog.jsx
@@ -161,6 +161,19 @@ var ModifiedChangeLog = React.createClass({
     }
 });
 
+var ReviewedChangeLog = React.createClass({
+    render: function() {
+        var changeLog = this.props.changeLog;
+        return (
+            <div>
+                <AuthorLink author={changeLog.author} />
+                <span> reviewed </span>
+                 { this.props.listingName }
+            </div>
+        );
+    }
+});
+
 var ReviewEditedChangeLog = React.createClass({
     render: function() {
         var changeLog = this.props.changeLog;
@@ -217,6 +230,7 @@ var ChangeLog = React.createClass({
         'DELETED' : ActionChangeLog,
         'REJECTED' : RejectedChangeLog,
         'APPROVED_ORG' : OrgApprovalChangeLog,
+        'REVIEWED' : ReviewedChangeLog,
         'REVIEW_EDITED' : ReviewEditedChangeLog,
         'REVIEW_DELETED' : ReviewDeletedChangeLog,
         'PENDING_DELETION' : PendingDeletionChangeLog

--- a/app/js/components/shared/ChangeLog.jsx
+++ b/app/js/components/shared/ChangeLog.jsx
@@ -180,8 +180,8 @@ var ReviewEditedChangeLog = React.createClass({
         return (
             <div>
                 <AuthorLink author={changeLog.author} />
-                <span> edited </span>
-                { (changeLog.changeDetails[0] === undefined) ? ' ' : changeLog.changeDetails[0].fieldName } in { this.props.listingName }
+                <span> edited review for </span>
+                { this.props.listingName }
             </div>
         );
     }


### PR DESCRIPTION
Add log entry to Recent Activity tab in Listing Management.
Add functionality for the 'view' link on review edited and review
created to forward to the reviews tab in a listing modal.

AMLNG-786

**Description**
As an Admin, I would like to see new listing reviews appear in ListingMngmt>Recent Activity to facilitate Admin notification of posted comments.

**Acceptance Criteria**
• when a user submits review a summary will appear in ListingMngmt>Recent Activity
• the summary will include a link to the review tab of the reviewed listing
• similar to when a review is deleted

**How to test code**
~~Test functionality by pulling https://github.com/aml-development/ozp-backend/tree/New_Action_log_addition~~ (Code merged in master.)
After creating a review, there will be an entry in /dist/#/user-management/recent-activity
The view button for the log entry should take the user to the review tab.
An edited log entry should do the same. 