### PR TITLE
feat(reviews): clicking stars/rating links to reviews

### DIFF
--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -64,7 +64,7 @@ var CenterLaunchLink = React.createClass({
 
         if (this.state.leavingOzpWarningFlag == true && this.state.currentUser.leavingOzpWarningFlag == true) {
             var me = this;
-
+            $(".SearchListingTile .clickable-rating").css({"z-index":"1"});
             timeout = setTimeout(function(){
                 me.reset();
             }, me.state.timeleft*1000);
@@ -137,6 +137,7 @@ var CenterLaunchLink = React.createClass({
     },
 
     reset: function(){
+        $(".SearchListingTile .clickable-rating").css({"z-index":"2"});
         this.setState({
             'launchWarning': false,
             'timeleft': time,

--- a/app/js/components/discovery/ListingTile.jsx
+++ b/app/js/components/discovery/ListingTile.jsx
@@ -37,6 +37,16 @@ var ListingTile = React.createClass({
       }
     },
 
+    goToReviews: function(e){
+        var href = this.makeHref(this.getActiveRoutePath(), null, {
+            listing: this.props.listing.id,
+            action: 'view',
+            tab: 'reviews'
+        });
+        window.location = href;
+        e.stopPropagation();
+    },
+
     render: function () {
         var listing = this.props.listing;
 
@@ -46,32 +56,36 @@ var ListingTile = React.createClass({
         var avgRate = listing.avgRate;
         var agencyShort = listing.agencyShort;
         var totalVotes = listing.totalReviews;
+
+        imageLargeUrl = listing.imageLargeUrl;
+
         var href = this.makeHref(this.getActiveRoutePath(), null, {
             listing: listing.id,
             action: 'view',
             tab: 'overview'
         });
 
-        imageLargeUrl = listing.imageLargeUrl;
-
         return (
-            <li onClick={this.handleClick.bind(this, this.props.from, listing.title)} className="listing SearchListingTile">
+            <div className="listing SearchListingTile">
                 <a className="listing-link"  href={ href }>
-                    {/* Empty link - css will make it cover entire <li>*/}
+                    {/* Empty link - css will make it cover entire <div>*/}
                     <span className="hidden-span">{listing.title}</span>
                 </a>
                 <img alt={`${listing.title} app tile`} src={ imageLargeUrl } />
                 <section className="slide-up">
                     <p className="title">{ name }</p>
-                    <IconRating
-                        {...this.props}
-                        className="icon-rating"
-                        viewOnly
-                        currentRating = { avgRate }
-                        toggledClassName="icon-star-filled-yellow"
-                        untoggledClassName="icon-star-filled-grayLighter"
-                        halfClassName="icon-star-half-filled-yellow"
-                        totalVotes={totalVotes} />
+                    <a className="clickable-rating" onClick={this.goToReviews}>
+                        <IconRating
+                            {...this.props}
+                            className="icon-rating"
+                            viewOnly
+                            currentRating = { avgRate }
+                            toggledClassName="icon-star-filled-yellow"
+                            untoggledClassName="icon-star-filled-grayLighter"
+                            halfClassName="icon-star-half-filled-yellow"
+                            totalVotes={totalVotes}
+                        />
+                    </a>
                     {
                         agencyShort &&
                         <span className="company">
@@ -84,7 +98,7 @@ var ListingTile = React.createClass({
                     <p className="description">{ description }</p>
                     { this.renderActions() }
                 </section>
-            </li>
+            </div>
         );
     },
 

--- a/app/js/components/discovery/RecommendedListingTileStorefront.jsx
+++ b/app/js/components/discovery/RecommendedListingTileStorefront.jsx
@@ -46,6 +46,16 @@ var RecommendedListingTileStorefront = React.createClass({
       }
     },
 
+    goToReviews: function(e){
+        var href = this.makeHref(this.getActiveRoutePath(), null, {
+            listing: this.props.listing.id,
+            action: 'view',
+            tab: 'reviews'
+        });
+        window.location = href;
+        e.stopPropagation();
+    },
+
     render: function () {
         var listing = this.props.listing;
         var name = listing.title;
@@ -54,32 +64,36 @@ var RecommendedListingTileStorefront = React.createClass({
         var avgRate = listing.avgRate;
         var agencyShort = listing.agencyShort;
         var totalVotes = listing.totalReviews;
+
+        imageLargeUrl = listing.imageLargeUrl;
+
         var href = this.makeHref(this.getActiveRoutePath(), null, {
             listing: listing.id,
             action: 'view',
             tab: 'overview'
         });
 
-        imageLargeUrl = listing.imageLargeUrl;
-
         return (
-            <li onClick={this.handleClick.bind(this, this.props.from, listing.title)} className="listing SearchListingTile">
+            <div className="listing SearchListingTile">
                 <a className="listing-link"  href={ href }>
-                    {/* Empty link - css will make it cover entire <li>*/}
+                    {/* Empty link - css will make it cover entire <div>*/}
                     <span className="hidden-span">{listing.title}</span>
                 </a>
                 <img alt={`${listing.title} app tile`} src={ imageLargeUrl } />
                 <section className="slide-up">
                     <p className="title">{ name }</p>
-                    <IconRating
-                        {...this.props}
-                        className="icon-rating"
-                        viewOnly
-                        currentRating = { avgRate }
-                        toggledClassName="icon-star-filled-yellow"
-                        untoggledClassName="icon-star-filled-grayLighter"
-                        halfClassName="icon-star-half-filled-yellow"
-                        totalVotes={totalVotes} />
+                    <a className="clickable-rating" onClick={this.goToReviews}>
+                        <IconRating
+                            {...this.props}
+                            className="icon-rating"
+                            viewOnly
+                            currentRating = { avgRate }
+                            toggledClassName="icon-star-filled-yellow"
+                            untoggledClassName="icon-star-filled-grayLighter"
+                            halfClassName="icon-star-half-filled-yellow"
+                            totalVotes={totalVotes}
+                        />
+                    </a>
                     {
                         agencyShort &&
                         <span className="company">
@@ -92,7 +106,7 @@ var RecommendedListingTileStorefront = React.createClass({
                     <p className="description">{ description }</p>
                     { this.renderActions() }
                 </section>
-            </li>
+            </div>
         );
     },
 

--- a/app/styles/_carousel.scss
+++ b/app/styles/_carousel.scss
@@ -14,7 +14,7 @@
         top: 0;
         left: 0;
         color: $white;
-        z-index:1;
+        z-index:2;
 
         > i {
             font-size: 2em;

--- a/app/styles/listing/_search-listing-tile.scss
+++ b/app/styles/listing/_search-listing-tile.scss
@@ -60,6 +60,16 @@
         font-size: $font-size-small;
     }
 
+    .clickable-rating{
+        display: inline-block;
+        position: relative;
+        z-index: 2;
+        &:hover{
+            border: 1px dotted lightblue;
+            margin: -1px;
+        }
+    }
+
     .company {
         background: $gray-lighter;
         padding: 2px 10px;


### PR DESCRIPTION
Modify the listing tiles to send the user to listing's reviews by
clicking on the rating in the listing's tile slideup.
Add styling to make new feature more noticable.

Closes AMLNG-580

**Acceptance Criteria**
Add link to the review tab by clicking on the stars in a listing tile.

**How to test code**
With center running, go to any of the tiles in center's mall. Hovering over them will bring up the slider. Clicking on the stars or number will send the user to the reviews tab of the listing. Clicking anywhere else in the slider will let the user see the listing.