### PR TITLE
fix(launch_notice): stop column break in requirements p

### DIFF
--- a/app/styles/_quickview.scss
+++ b/app/styles/_quickview.scss
@@ -504,6 +504,12 @@ ul.list-unstyled.RecentActivity
 .LaunchConfirmation__columns {
     column-count: 2;
     padding-bottom: 45px;
+
+    p {
+        -webkit-column-break-inside: avoid;
+        page-break-inside: avoid;
+        break-inside: avoid-column;
+    }
 }
 
 .Review {


### PR DESCRIPTION
The Usage and System Requirements sections are broken up using a column-count: 2 style.  But that tries to make the columns even.

I noticed in the Listing 'Tornado', that the Usage Requirements section was broken up and was showing over the System Requirements header. 

This fixes that.

To Test:
Look at Tornado's Launch notice Usage Requirements before pulling code.
Look at Tornado's Launch notice Usage Requirements AFTER pulling code.