### PR TITLE
fix(launch popup): show requirements information

### DIFF
--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -115,19 +115,6 @@ var CenterLaunchLink = React.createClass({
 
     },
 
-    goToDetails: function(){
-        this.reset();
-
-        var href = this.makeHref(this.getActiveRoutePath(),this.getParams(), {
-            listing: this.props.listing.id,
-            action: 'view',
-            tab: 'details'
-        });
-
-        window.location.replace(href);
-
-    },
-
     cancelTimer : function(e){
         this.setState({'showTimeout': false, 'timeleft': time});
         clearTimeout(timeout);
@@ -154,24 +141,19 @@ var CenterLaunchLink = React.createClass({
         var { listing } = this.getQuery();
         var modalClass = "LaunchConfirmation"
         if(!listing)
-            modalClass += ' listingLaunchConfirmation';
+            modalClass += ' listingLaunchConfirmation quickview';
 
         var launchModal = this.state.currentUser && this.state.currentUser.leavingOzpWarningFlag ? (<Modal ref="modal" className={modalClass} size="small" modaltitle={"Notice: You are leaving " + APP_TITLE + "!"} onCancel={this.modalConfirmation}>
                   <strong>
                       <p className="LaunchConfirmation__content">Please review the requirements below if you have problems launching <b>{this.props.listing.title}</b>:</p>
                       <br/>
-                      { listing &&
-                          <div className="LaunchConfirmation__columns">
-                              <h5>Usage Requirements</h5>
-                              <p>{this.props.listing.usage_requirements}</p>
+                      <div className="LaunchConfirmation__columns">
+                          <h5>Usage Requirements</h5>
+                          <p>{this.props.listing.usage_requirements}</p>
 
-                              <h5>System Requirements</h5>
-                              <p>{this.props.listing.system_requirements}</p>
-                          </div>
-                      }
-                      {!listing &&
-                          <button style={{'marginBottom': '40px'}} className="btn btn-info" onClick={this.goToDetails}>Click Here</button>
-                      }
+                          <h5>System Requirements</h5>
+                          <p>{this.props.listing.system_requirements}</p>
+                      </div>
                       <span style={{'clear': 'both'}}>
                           <p>Or contact the owners of {this.props.listing.title} by clicking here:
                           <button className="btn btn-info" onClick={this.goToContactOwners}>Contact Owners</button></p>


### PR DESCRIPTION
add system and usage requirements information to launch from thumbnail
view

closes AMLNG-798

**Description**
Pre-req - Define system and usage requirements in an App Listing. In Profile Settings , Enable the option Show Launch Requirements Notice
Go to Homepage
From Thumbnail view, Launch App from thumbnail view

**Acceptance Criteria**
RESULTS - Sys/Usage requirements pop up displays without the actual system / usage requirements.
EXPECTED RESULTS - Sys/usage requirements from pre-requisites should display on the this pop up.
Open Quick View Modal
Launch App
RESULTS - Sys/usage requirements from the prerequisites display on the pop up as they should.

**How to test code**
Pull amlng798 from ozp-backend
Pull amlng798 from ozp-center