### PR TITLE
fix(launch popup): properly close modal when clicking OK

### DIFF
--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -79,12 +79,17 @@ var CenterLaunchLink = React.createClass({
 
     modalConfirmation: function(){
         var profile = this.state.currentUser;
+        var { listing } = this.getQuery();
         profile.leavingOzpWarningFlag = this.state.leavingOzpWarningFlag;
 
         ProfileActions.updateProfileFlags(profile);
         ProfileActions.fetchProfile(profile.profileId);
 
         this.reset();
+
+        if(!listing) {
+            this.close();
+        }
     },
 
     optWarning: function(event) {
@@ -132,6 +137,10 @@ var CenterLaunchLink = React.createClass({
         });
         clearTimeout(timeout);
         clearInterval(timer);
+    },
+
+    close: function () {
+        this.refs.modal.close();
     },
 
     render: function() {


### PR DESCRIPTION
add close function on CenterLaunchLink

closes AMLNG-833

**Description**
Scrollbar disappears once you press the OK button on the launch notice modal. Issue most likely comes from the fact that the OK button is calling a method and forgot to call the closeModal function.

**Acceptance Criteria**
Go to Homepage
From Thumbnail view, Launch App from thumbnail view
Click OK to close modal window
EXPECTED - App returns to normal state with functional scrollbar
RESULTS - Scrollbar no longer allows scroll

**How to test code**
Pull amlng833 from ozp-center