### PR TITLE
feat(discovery): show spinner when performing a search

### DIFF
--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -617,7 +617,10 @@ var Discovery = React.createClass({
                 </ul>
                 <p className="text-center">
                   { this.state.loadingMore &&
-                    <h3 className="col-xs-12">Searching...</h3>
+                    <section>
+                        <h4>Loading...</h4>
+                        <span className="icon-loader-36 loader loader-animate"></span>
+                    </section>
                   }
                 </p>
             </section>
@@ -678,7 +681,10 @@ var Discovery = React.createClass({
                 </ul>
                 <div className="list-unstyled listings-search-results row clearfix">
                     { this.state.searching &&
-                      <h3 className="col-xs-12">Searching...</h3>
+                      <section>
+                          <h4>Loading...</h4>
+                          <span className="icon-loader-36 loader loader-animate"></span>
+                      </section>
                     }
                 </div>
             </section>


### PR DESCRIPTION
Add spinner indicator when a back-end call to elasticsearch is performed (category, agency, listing type, text search)

closes AMLNG-810

**Description**
When filtering Center by category, update page loading process to implement page loading indicator image used when Center page first loads.

**Acceptance Criteria**
Use site data loading indicator image as placeholder until result set is displayed
Same layout as center page

**How to test code**
Pull branch amlng810 from ozp-center