### PR TITLE
feat(listing management): add load indicators in listing management

### DIFF
--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -461,8 +461,7 @@ var Discovery = React.createClass({
         if(!this.state.featured.length) {
             return (
                 [<h4>Featured</h4>,
-                <LoadIndicator title=""
-                    showError={this.state.featuredError}
+                <LoadIndicator showError={this.state.featuredError}
                     errorMessage="Error loading Featured Listings"/>]
             );
         }
@@ -478,8 +477,7 @@ var Discovery = React.createClass({
         if(!this.state.recommended.length) {
             return (
                 [<h4>{listingMessages['recommender.recommended']}</h4>,
-                <LoadIndicator title=""
-                    showError={this.state.recommendedError}
+                <LoadIndicator showError={this.state.recommendedError}
                     errorMessage="Error loading Recommended Listings"/>]
             );
         }
@@ -498,8 +496,7 @@ var Discovery = React.createClass({
         if(!this.state.newArrivals.length) {
             return (
                 [<h4>New Arrivals</h4>,
-                <LoadIndicator title=""
-                    showError={this.state.newArrivalsError}
+                <LoadIndicator showError={this.state.newArrivalsError}
                     errorMessage="Error loading New Arrivals Listings"/>]
             );
         }
@@ -567,8 +564,7 @@ var Discovery = React.createClass({
         if(!this.state.mostPopular.length) {
             return (
                 [<h4>Most Popular</h4>,
-                <LoadIndicator title=""
-                    showError={this.state.mostPopularError}
+                <LoadIndicator showError={this.state.mostPopularError}
                     errorMessage="Error loading Most Popular Listings"/>]
             );
         }

--- a/app/js/components/discovery/index.jsx
+++ b/app/js/components/discovery/index.jsx
@@ -25,6 +25,7 @@ var DetailedQuery = require('./DetailedQuery.jsx');
 var ActiveStateMixin = require('../../mixins/ActiveStateMixin');
 
 var SelectBox = require('../shared/SelectBox.jsx');
+var LoadIndicator = require('../shared/LoadIndicator.jsx');
 
 var $ = require('jquery');
 require('../../utils/typeahead.js');
@@ -458,21 +459,11 @@ var Discovery = React.createClass({
 
     renderFeaturedListings() {
         if(!this.state.featured.length) {
-            if (this.state.featuredError) {
-                return(
-                    <section>
-                        <h4>Featured</h4>
-                        <span className="icon-exclamation-36 loader"></span>
-                        <h5 className="loader-message">Error loading Featured Listings</h5>
-                    </section>
-                )
-            }
-
             return (
-                <section>
-                    <h4>Featured</h4>
-                    <span className="icon-loader-36 loader loader-animate"></span>
-                </section>
+                [<h4>Featured</h4>,
+                <LoadIndicator title=""
+                    showError={this.state.featuredError}
+                    errorMessage="Error loading Featured Listings"/>]
             );
         }
 
@@ -483,47 +474,33 @@ var Discovery = React.createClass({
         );
     },
 
-    renderRecommended(){
-        if(this.state.recommended.length){
-            if (this.state.recommendedError) {
-                return(
-                    <section>
-                        <h4>{listingMessages['recommender.recommended']}</h4>
-                        <span className="icon-exclamation-36 loader"></span>
-                        <h5 className="loader-message">Error loading Recommended Listings</h5>
-                    </section>
-                )
-            }
-
+    renderRecommended() {
+        if(!this.state.recommended.length) {
             return (
-                <section className="Discovery__Recommended" key="Discovery__Recommended">
+                [<h4>{listingMessages['recommender.recommended']}</h4>,
+                <LoadIndicator title=""
+                    showError={this.state.recommendedError}
+                    errorMessage="Error loading Recommended Listings"/>]
+            );
+        }
+
+        return (
+            <section className="Discovery__Recommended" key="Discovery__Recommended">
                 <h4>{listingMessages['recommender.recommended']}</h4>
                 <Carousel className="new-arrival-listings" aria-label="Recommended Apps Carousel">
                     { RecommendedListingTileStorefront.fromArray(this.state.recommended, listingMessages['recommender.recommended']) }
                 </Carousel>
             </section>
-            );
-        }
-
+        );
     },
 
     renderNewArrivals() {
         if(!this.state.newArrivals.length) {
-            if (this.state.featuredError) {
-                return(
-                    <section>
-                        <h4>New Arrivals</h4>
-                        <span className="icon-exclamation-36 loader"></span>
-                        <h5 className="loader-message">Error loading New Arrivals Listings</h5>
-                    </section>
-                )
-            }
-
             return (
-                <section>
-                    <h4>New Arrivals</h4>
-                    <span className="icon-loader-36 loader loader-animate"></span>
-                </section>
+                [<h4>New Arrivals</h4>,
+                <LoadIndicator title=""
+                    showError={this.state.newArrivalsError}
+                    errorMessage="Error loading New Arrivals Listings"/>]
             );
         }
 
@@ -588,21 +565,11 @@ var Discovery = React.createClass({
 
     renderMostPopular() {
         if(!this.state.mostPopular.length) {
-            if (this.state.featuredError) {
-                return(
-                    <section className="loader">
-                        <h4>Most Popular</h4>
-                        <span className="icon-exclamation-36 loader"></span>
-                        <h5 className="loader-message">Error loading Most Popular Listings</h5>
-                    </section>
-                )
-            }
-
             return (
-                <section>
-                    <h4>Most Popular</h4>
-                    <span className="icon-loader-36 loader loader-animate"></span>
-                </section>
+                [<h4>Most Popular</h4>,
+                <LoadIndicator title=""
+                    showError={this.state.mostPopularError}
+                    errorMessage="Error loading Most Popular Listings"/>]
             );
         }
 
@@ -616,12 +583,7 @@ var Discovery = React.createClass({
                     { InfiniTiles }
                 </ul>
                 <p className="text-center">
-                  { this.state.loadingMore &&
-                    <section>
-                        <h4>Loading...</h4>
-                        <span className="icon-loader-36 loader loader-animate"></span>
-                    </section>
-                  }
+                  { this.state.loadingMore && <LoadIndicator/> }
                 </p>
             </section>
         );
@@ -680,12 +642,7 @@ var Discovery = React.createClass({
                     { results }
                 </ul>
                 <div className="list-unstyled listings-search-results row clearfix">
-                    { this.state.searching &&
-                      <section>
-                          <h4>Loading...</h4>
-                          <span className="icon-loader-36 loader loader-animate"></span>
-                      </section>
-                    }
+                    { this.state.searching && <LoadIndicator/> }
                 </div>
             </section>
         );

--- a/app/js/components/management/AllListings/index.jsx
+++ b/app/js/components/management/AllListings/index.jsx
@@ -40,6 +40,7 @@ var AllListings = React.createClass({
         this.setState({
             filter: this.state.filter
         });
+        this.refs.listingView.clearListings();
         if(this.state.tableView){
             this.state.filter.offset = 0;
             w2ui.grid.offset = 0;
@@ -66,13 +67,13 @@ var AllListings = React.createClass({
     renderListings: function () {
         if (this.state.tableView === true) {
             return (
-                <TableView className="ListingsManagement__TableView"
+                <TableView ref="listingView" className="ListingsManagement__TableView"
                     filter={this.state.filter} onCountsChanged={this.onCountsChanged} tableName="AllListings_Listings"
                     isAdmin={true} showOrg={true}></TableView>
             );
         } else {
             return (
-                <LoadMore className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
+                <LoadMore ref="listingView" className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
                     filter={this.state.filter} onCountsChanged={this.onCountsChanged}></LoadMore>
             );
         }

--- a/app/js/components/management/AllListings/index.jsx
+++ b/app/js/components/management/AllListings/index.jsx
@@ -40,7 +40,10 @@ var AllListings = React.createClass({
         this.setState({
             filter: this.state.filter
         });
-        this.refs.listingView.clearListings();
+        if(this.refs.loadMore) {
+            this.refs.loadMore.clear();
+            this.refs.loadMore.initLoad();
+        }
         if(this.state.tableView){
             this.state.filter.offset = 0;
             w2ui.grid.offset = 0;
@@ -67,13 +70,13 @@ var AllListings = React.createClass({
     renderListings: function () {
         if (this.state.tableView === true) {
             return (
-                <TableView ref="listingView" className="ListingsManagement__TableView"
+                <TableView className="ListingsManagement__TableView"
                     filter={this.state.filter} onCountsChanged={this.onCountsChanged} tableName="AllListings_Listings"
                     isAdmin={true} showOrg={true}></TableView>
             );
         } else {
             return (
-                <LoadMore ref="listingView" className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
+                <LoadMore ref="loadMore" className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
                     filter={this.state.filter} onCountsChanged={this.onCountsChanged}></LoadMore>
             );
         }

--- a/app/js/components/management/OrgListings/index.jsx
+++ b/app/js/components/management/OrgListings/index.jsx
@@ -23,7 +23,7 @@ var OrgListings = React.createClass({
     mixins: [
         SystemStateMixin,
         ActiveStateMixin,
-        UserRoleMixin.OrgSteward,
+        UserRoleMixin.OrgSteward
     ],
 
     getInitialState: function () {
@@ -42,6 +42,10 @@ var OrgListings = React.createClass({
 
     onFilterChanged: function (key, value) {
         this.state.filter[key] = value;
+        if(this.refs.loadMore) {
+            this.refs.loadMore.clear();
+            this.refs.loadMore.initLoad();
+        }
         if(this.state.tableView){
             UnpaginatedListingsStore.filterChange(this.state.filter);
         } else {
@@ -81,7 +85,7 @@ var OrgListings = React.createClass({
             );
         } else {
             return (
-                <LoadMore className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
+                <LoadMore ref="loadMore" className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
                     filter={this.state.filter} onCountsChanged={this.onCountsChanged}></LoadMore>
             );
         }

--- a/app/js/components/management/shared/LoadMore.jsx
+++ b/app/js/components/management/shared/LoadMore.jsx
@@ -17,8 +17,6 @@ var LoadMore = React.createClass({
     mixins: [
         Reflux.listenTo(PaginatedListingsStore, 'onStoreChanged'),
         Reflux.listenTo(ListingActions.listingChangeCompleted, 'onListingChangeCompleted'),
-        Reflux.listenTo(ListingActions.fetchAllListings, 'onFetchAllListings'),
-        Reflux.listenTo(ListingActions.fetchAllListingsCompleted, 'onFetchAllListingsCompleted'),
         Reflux.listenTo(ListingActions.fetchAllListingsFailed, 'onFetchAllListingsFailed')
     ],
 
@@ -54,6 +52,9 @@ var LoadMore = React.createClass({
 
         if (children && children.length > 0 && !this.state.loadingError) {
             return <ol className="list-unstyled">{ children }</ol>;
+        }
+        else if(!this.state.loading) {
+            return <h5 style={{marginTop: "0"}}>No results found!</h5>;
         }
     },
 
@@ -96,50 +97,54 @@ var LoadMore = React.createClass({
 
         this.setState({
             listings: data,
-            hasMore: hasMore,
-            loading: false,
-            loadingError: false
+            hasMore: hasMore
         });
+        this.loadSuccess();
 
         this.props.onCountsChanged(counts);
     },
 
     onListingChangeCompleted: function () {
+        this.initLoad();
         ListingActions.fetchAllListings(this.props.filter);
+    },
+
+    onFetchAllListingsFailed: function () {
+        this.loadError();
     },
 
     onLoadMore: function () {
+        this.initLoad();
         ListingActions.fetchAllListings(this.props.filter);
     },
 
-    onFetchAllListings() {
+    clear() {
+        this.setState({
+            listings: []
+        });
+    },
+
+    initLoad() {
         this.setState({
             loading: true,
             loadingError: false
         });
     },
 
-    onFetchAllListingsCompleted() {
+    loadSuccess() {
         this.setState({
             loading: false,
             loadingError: false
         });
     },
 
-    onFetchAllListingsFailed() {
+    loadError() {
         this.setState({
             loading: false,
             loadingError: true
         });
-    },
-
-    clearListings() {
-        this.setState({
-            listings: [],
-            loading: true,
-            loadingError: false
-        });
     }
+
 });
 
 module.exports = LoadMore;

--- a/app/js/components/management/user/MyListings.jsx
+++ b/app/js/components/management/user/MyListings.jsx
@@ -2,7 +2,6 @@
 
 var React = require('react');
 var Router = require('react-router');
-var Reflux = require('reflux');
 
 var PaginatedListingsStore = require('../../../stores/PaginatedListingsStore');
 var UnpaginatedListingsStore = require('../../../stores/UnpaginatedListingsStore');
@@ -39,6 +38,10 @@ var MyListings = React.createClass({
         this.setState({
             filter: this.state.filter
         });
+        if(this.refs.loadMore) {
+            this.refs.loadMore.clear();
+            this.refs.loadMore.initLoad();
+        }
         if(this.state.tableView){
             this.state.filter.offset = 0;
             w2ui.grid.offset = 0;
@@ -79,7 +82,7 @@ var MyListings = React.createClass({
             );
         } else {
             return (
-                <LoadMore className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
+                <LoadMore ref="loadMore" className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
                     filter={this.state.filter} onCountsChanged={this.onCountsChanged}></LoadMore>
                 );
             }

--- a/app/js/components/management/user/RecentActivity.jsx
+++ b/app/js/components/management/user/RecentActivity.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var Reflux = require('reflux');
 var { Navigation } = require('react-router');
 var Sidebar = require('./RecentActivitySidebar.jsx');
 var ListingActions = require('../../../actions/ListingActions');
@@ -16,7 +17,8 @@ var RecentActivity = React.createClass({
     mixins: [
         Navigation,
         ActiveState,
-        SystemStateMixin
+        SystemStateMixin,
+        Reflux.listenTo(ListingActions.fetchAllChangeLogsFailed, 'onFetchAllChangeLogsFailed')
     ],
 
     getInitialState: function () {
@@ -26,11 +28,13 @@ var RecentActivity = React.createClass({
     },
 
     componentDidMount: function () {
+        this.refs.loadMore.initLoad();
         this.fetchAllChangeLogsIfEmpty();
         this.listenTo(PaginatedChangeLogStore, this.onChangeLogsReceived);
     },
 
     onLoadMore: function() {
+        this.refs.loadMore.initLoad();
         ListingActions.fetchAllChangeLogs(this.state.currentUser);
     },
 
@@ -44,6 +48,7 @@ var RecentActivity = React.createClass({
             changeLogs: data,
             hasMore: hasMore
         });
+        this.refs.loadMore.loadSuccess();
     },
 
     createLink: function (changeLog) {
@@ -113,6 +118,10 @@ var RecentActivity = React.createClass({
         this.onChangeLogsReceived();
     },
 
+    onFetchAllChangeLogsFailed() {
+        this.refs.loadMore.loadError();
+    },
+
     renderChangeLogs: function () {
         var me = this;
 
@@ -148,7 +157,7 @@ var RecentActivity = React.createClass({
                 <div className="RecentActivity__Sidebar col-xs-5 col-lg-4"><Sidebar /></div>
                 <div className="RecentActivity__Content col-xs-7 col-lg-8">
                     <h3>Recent Activity</h3>
-                        <LoadMore className="RecentActivity__activities all"
+                        <LoadMore ref="loadMore" className="RecentActivity__activities all"
                                   hasMore={hasMore} onLoadMore={this.onLoadMore}>
                             { logs }
                         </LoadMore>
@@ -156,7 +165,6 @@ var RecentActivity = React.createClass({
             </div>
         );
     }
-
 
 });
 

--- a/app/js/components/quickview/index.jsx
+++ b/app/js/components/quickview/index.jsx
@@ -151,7 +151,7 @@ var Quickview = React.createClass({
                 {
                     !listing || !listing.title ?
                         <h1 style={{'height': '550px'}} className="quickview-header listing-title">
-                            Loading...<LoadIndicator title=""/>
+                            <LoadIndicator/>
                         </h1> :
                         [
                             <Header { ...headerProps }  key="header"></Header>,

--- a/app/js/components/quickview/index.jsx
+++ b/app/js/components/quickview/index.jsx
@@ -22,6 +22,7 @@ var AdministrationTab = require('./AdministrationTab.jsx');
 var NotificationsTab = require('./NotificationsTab.jsx');
 var Recommendations = require('./Recommendations.jsx');
 var ListingActions = require('../../actions/ListingActions');
+var LoadIndicator = require('../shared/LoadIndicator.jsx');
 
 var tabs = {
     'overview': OverviewTab,
@@ -149,7 +150,9 @@ var Quickview = React.createClass({
             <Modal ref="modal" className="quickview" onShown={this.onShown} onHidden={this.onHidden} tabIndex="0">
                 {
                     !listing || !listing.title ?
-                        <h1 style={{'height': '550px'}} className="quickview-header listing-title">Loading...<span className="icon-loader-36 loader loader-animate"></span></h1> :
+                        <h1 style={{'height': '550px'}} className="quickview-header listing-title">
+                            Loading...<LoadIndicator title=""/>
+                        </h1> :
                         [
                             <Header { ...headerProps }  key="header"></Header>,
                             <div className="tabs-container" key="tabs-container">

--- a/app/js/components/shared/LoadIndicator.jsx
+++ b/app/js/components/shared/LoadIndicator.jsx
@@ -3,12 +3,6 @@
 var React = require('react');
 
 var LoadIndicator = React.createClass({
-    getDefaultProps() {
-        return {
-            title: 'Loading...'
-        };
-    },
-
     render() {
         var title = this.props.showError ? null : this.props.title;
         var loadIcon = this.props.showError ?

--- a/app/js/components/shared/LoadIndicator.jsx
+++ b/app/js/components/shared/LoadIndicator.jsx
@@ -1,0 +1,41 @@
+'use strict';
+
+var React = require('react');
+
+var LoadIndicator = React.createClass({
+    getDefaultProps() {
+        return {
+            title: 'Loading...'
+        };
+    },
+
+    render() {
+        var title = this.props.showError ? null : this.props.title;
+        var loadIcon = this.props.showError ?
+            <span className="icon-exclamation-36 loader"></span> :
+            <span className="icon-loader-36 loader loader-animate"></span>;
+        var displayMessage = this.props.showError ?
+            this.props.errorMessage : this.props.message;
+
+        return (
+            <section className="loader">
+                { title &&
+                    <h5 className="loader-title">{ title }</h5>
+                }
+                { loadIcon }
+                { displayMessage &&
+                    <h5 className="loader-message">{ displayMessage }</h5>
+                }
+            </section>
+        );
+    },
+
+    shouldComponentUpdate(newProps) {
+        return newProps.title !== this.props.title
+            || newProps.message !== this.props.message
+            || newProps.showError !== this.props.showError
+            || newProps.errorMessage !== this.props.errorMessage;
+    }
+});
+
+module.exports = LoadIndicator;

--- a/app/js/components/shared/LoadMore.jsx
+++ b/app/js/components/shared/LoadMore.jsx
@@ -3,6 +3,8 @@
 var React = require('react');
 var { PropTypes } = React;
 
+var LoadIndicator = require('../shared/LoadIndicator.jsx');
+
 var LoadMore = React.createClass({
 
     propTypes: {
@@ -13,10 +15,21 @@ var LoadMore = React.createClass({
         onLoadMore: PropTypes.func.isRequired
     },
 
+    getInitialState: function () {
+        return {
+            loading: false,
+            loadingError: false
+        };
+    },
+
     render: function () {
         return (
             <div className="LoadMore" {...this.props}>
                 { this.renderList() }
+                { (this.state.loading || this.state.loadingError) &&
+                    <LoadIndicator showError={this.state.loadingError}
+                        errorMessage="Error Loading Listings"/>
+                }
                 { this.renderLoadMoreButton() }
             </div>
         );
@@ -28,22 +41,43 @@ var LoadMore = React.createClass({
             children = this.props.children;
         }
 
-        if (children && children.length > 0) {
+        if (children && children.length > 0 && !this.state.loadingError) {
             return <ol className="list-unstyled">{ this.props.children }</ol>;
         }
-        else {
+        else if(!this.state.loading) {
             return <h5 style={{marginTop: "0"}}>No results found!</h5>;
         }
     },
 
     renderLoadMoreButton: function () {
-        if (this.props.hasMore) {
+        if (this.props.hasMore && !this.state.loading) {
             return (
                 <div className="text-center LoadMore__Toolbar">
                     <button className="btn btn-default LoadMore__Button" onClick={this.props.onLoadMore}>Load More</button>
                 </div>
             );
         }
+    },
+
+    initLoad() {
+        this.setState({
+            loading: true,
+            loadingError: false
+        });
+    },
+
+    loadSuccess() {
+        this.setState({
+            loading: false,
+            loadingError: false
+        });
+    },
+
+    loadError() {
+        this.setState({
+            loading: false,
+            loadingError: true
+        });
     }
 
 });

--- a/app/styles/_discovery.scss
+++ b/app/styles/_discovery.scss
@@ -240,6 +240,10 @@
     display: block;
 }
 
+.loader-title {
+    text-align: center;
+}
+
 .loader-message {
     text-align: center;
 }


### PR DESCRIPTION
closes AMLNG-805, 806, and 807

**Description**
Update page loading process for Listing Management>My Listings, All Center Listings, and Recent Activity to use the same loading indicator as when the center page first loads.

**Acceptance Criteria**
Use site data loading indicator image as placeholder until result set is displayed
Same layout as center page
API calls (search, filtering, load more, etc) use load indicator
Both list and table views use load indicator

**How to test code**
Pull branch amlng-805-806-807