### PR TITLE
style(listing managment): move enabled filter

### DIFF
--- a/app/js/components/management/AllListings/index.jsx
+++ b/app/js/components/management/AllListings/index.jsx
@@ -112,8 +112,8 @@ var AllListings = React.createClass({
                     <Sidebar>
                         {toggleSwitch}
                         <ApprovalStatusFilter role={ UserRole.APPS_MALL_STEWARD } { ...sidebarFilterOptions } />
-                        <OrgFilter { ...sidebarFilterOptions } />
                         <EnabledFilter { ...sidebarFilterOptions } />
+                        <OrgFilter { ...sidebarFilterOptions } />
                     </Sidebar>
                 </div>
                 { this.renderListings() }


### PR DESCRIPTION
Moves enabled filter to below status in sidebar

Closes #AMLNG-822

**How to test**
Go to listing management, Enabled should be located beneath Status filter in sidebar on left.