### PR TITLE
fix(listing management): correctly sync data with table views on edit…

### DIFF
--- a/app/js/stores/UnpaginatedListingsStore.js
+++ b/app/js/stores/UnpaginatedListingsStore.js
@@ -35,22 +35,25 @@ var UnpaginatedListingsStore = Reflux.createStore({
     onFetchAllListingsAtOnceCompleted: function (filter, response) {
         var key = filterKey(filter);
         var page = new PaginatedList (response);
-     
+
         _unpaginatedListByFilter[key] = page;
         this.trigger();
     },
 
     onListingChangeCompleted: function (data) {
+        var dataChanged = false;
         for (var key in _unpaginatedListByFilter){
             var list = _unpaginatedListByFilter[key].data;
             for (var listing in list){
                 var entry = list[listing];
                 if (entry.id == data.id){
                     list[listing] = data;
-                    this.trigger();
-                    return;
+                    dataChanged = true;
                 }
             }
+        }
+        if(dataChanged) {
+            this.trigger();
         }
     },
 


### PR DESCRIPTION
Fix the table view not updating

Log onto Apps Mall as bigbrother

Go to Listing Management View | Table View ONLY

Choose Published Filter

Delete an app listing

RESULTS - Left side filter - Published  Filter total reduces by 1 and Deleted Filter increments by 1. (PASSED)  The Table View still displayed the deleted app while the Published Filter was selected(FAILED)

 

EXPECTED RESULTS - Left side filter - Published Filter total reduces by 1 and Deleted Filter increments by 1.  The Table View should NOT display the deleted app while the Published Filter is selected.

The actual results should still show the deleted app