### PR TITLE
fix(launch popup): modal correctly stacks on top when launched

### DIFF
--- a/app/js/components/CenterLaunchLink.jsx
+++ b/app/js/components/CenterLaunchLink.jsx
@@ -35,6 +35,8 @@ function getState(profileData) {
 var CenterLaunchLink = React.createClass({
     mixins: [Reflux.listenTo(SelfStore, 'onStoreUpdate'), Reflux.connect(SelfStore), Navigation, CurrentPath, State],
 
+    _elementsToFixOnLaunch: ".SearchListingTile .clickable-rating, .carousel__arrow, #header, #sub-header, #globalNav",
+
     propTypes: {
         listing: React.PropTypes.object.isRequired
     },
@@ -63,8 +65,12 @@ var CenterLaunchLink = React.createClass({
         });
 
         if (this.state.leavingOzpWarningFlag == true && this.state.currentUser.leavingOzpWarningFlag == true) {
+            $(this._elementsToFixOnLaunch).each(function() {
+                $(this).attr('data-original-z-index', $(this).css('z-index'));
+                $(this).css('z-index', 1);
+            });
+
             var me = this;
-            $(".SearchListingTile .clickable-rating").css({"z-index":"1"});
             timeout = setTimeout(function(){
                 me.reset();
             }, me.state.timeleft*1000);
@@ -129,7 +135,13 @@ var CenterLaunchLink = React.createClass({
     },
 
     reset: function(){
-        $(".SearchListingTile .clickable-rating").css({"z-index":"2"});
+        $(this._elementsToFixOnLaunch).each(function() {
+            if($(this).is("[data-original-z-index]")) {
+                $(this).css('z-index', '');
+                $(this).removeAttr('data-original-z-index');
+            }
+        });
+
         this.setState({
             'launchWarning': false,
             'timeleft': time,


### PR DESCRIPTION
**Description**
When launching a listing from the thumbnail, ensure that the modal popup correctly stacks on top of the UI, meaning the rest of the UI sits under the gray background behind the modal

**Acceptance Criteria**
Go to the center page
Launch a listing from the thumbnail
RESULTS: Main navigation bar, search bar, and carousel arrows are still clickable and sit on top of the modal background
EXPECTED RESULTS: UI components are un-clickable and grayed out under the modal background

**How to test code**
Pull modal_stacking_hotfix from ozp-center