### PR TITLE
refactor(PastNotification): refactor to use store

### DIFF
--- a/app/js/actions/NotificationActions.js
+++ b/app/js/actions/NotificationActions.js
@@ -44,19 +44,14 @@ var NotificationActions = createActions({
           .fail(NotificationActions.fetchOwnNotificationsFailed);
     },
 
-    fetchPast(paginatedList) {
-        var url;
-        if (paginatedList && paginatedList.nextLink) {
-            url = paginatedList.nextLink;
-        }
-
-        NotificationApi.fetchPast(url)
+    fetchPast() {
+        NotificationApi.fetchPast()
             .then(NotificationActions.fetchPastCompleted)
             .fail(NotificationActions.fetchPastFailed);
     },
 
     fetchPastById(id) {
-      NotificationApi.fetchPast(null, id)
+      NotificationApi.fetchPast(id)
           .then(NotificationActions.fetchPastCompleted)
           .fail(NotificationActions.fetchPastFailed);
     },

--- a/app/js/components/management/mall/notifications/__tests__/CreateNotification-test.js
+++ b/app/js/components/management/mall/notifications/__tests__/CreateNotification-test.js
@@ -41,9 +41,12 @@ describe('CreateNotification', function () {
         var createNotification = TestUtils.renderIntoDocument(<CreateNotification fn={() => function(){this.setState({message: message});}}/>);
         var resetSpy = sinon.spy(createNotification, 'onReset');
         var setStateSpy = sinon.spy(createNotification, 'setState');
+        var date = new Date();
+        date.setDate(date.getDate() + 1);
         NotificationActions.createNotificationCompleted(createNotification.state.uuid, {
             id: Math.random(),
-            message: 'TEST'
+            message: 'TEST',
+            expiresDate: date
         });
         expect(resetSpy.calledOnce).to.be.ok;
 

--- a/app/js/components/management/mall/notifications/index.jsx
+++ b/app/js/components/management/mall/notifications/index.jsx
@@ -57,6 +57,10 @@ var ActiveNotifications = React.createClass({
         this.setState(this.getState());
     },
 
+    componentWillMount() {
+        NotificationActions.fetchActive();
+    },
+
     componentDidMount() {
         var { hasMore } = this.state;
         if (hasMore) {
@@ -133,6 +137,11 @@ var PastNotifications = React.createClass({
             NotificationActions.fetchPast(this.notifications());
         }
     },
+
+    componentWillMount() {
+        NotificationActions.fetchPast();
+    },
+
 
     componentDidMount() {
         if (!this.state.notifications || this.state.notifications.length === 0) {

--- a/app/js/stores/ActiveNotificationStore.js
+++ b/app/js/stores/ActiveNotificationStore.js
@@ -27,10 +27,11 @@ var ActiveNotificationStore = Reflux.createStore({
     },
 
     onCreateCompleted(uuid, notification) {
-        _notifications.data.unshift(notification);
-        this.trigger();
+        if (notification.expiresDate.toISOString() > notification.createdDate){
+            _notifications.data.unshift(notification);
+            this.trigger();
+        }
     },
-
     onExpireCompleted(notification) {
         _.remove(_notifications.data, { id: notification.id });
         this.trigger();

--- a/app/js/stores/__tests__/PastNotificationStore-test.js
+++ b/app/js/stores/__tests__/PastNotificationStore-test.js
@@ -8,20 +8,20 @@ describe('PastNotificationStore', () => {
 
     var PastNotificationStore = require('../PastNotificationStore');
 
-    it.skip('fetches past notifications when notification is created or expired', (done) => {
+    it('fetches past notifications when notification is created or expired', (done) => {
         var fetchPastStub = sinon.stub(NotificationActions, 'fetchPast');
-        var notificationList = PastNotificationStore.getNotifications();
+        var notificationList = JSON.parse(JSON.stringify(PastNotificationStore.getNotifications()));
+        var date = new Date();
+        date.setDate(date.getDate() - 1);
         var notification = {
             id: 1,
-            message: 'TEST'
+            message: 'TEST',
+            createdDate: new Date().toISOString(),
+            expiresDate: date
         };
+
         NotificationActions.createNotificationCompleted(Math.random(), notification);
         NotificationActions.expireNotificationCompleted(notification);
-
-        expect(fetchPastStub.calledTwice).to.be.ok;
-        expect(fetchPastStub.calledWith(undefined)).to.be.ok;
-
-        NotificationActions.fetchPastCompleted();
 
         setTimeout(() => {
             expect(notificationList).to.not.eql(PastNotificationStore.getNotifications());

--- a/app/js/webapi/Notification.js
+++ b/app/js/webapi/Notification.js
@@ -66,8 +66,8 @@ module.exports = {
       });
     },
 
-    fetchPast(url, id) {
-        url = url || `${API_URL}/api/notifications/expired/?offset=0&limit=${PAGINATION_MAX}`;
+    fetchPast(id) {
+        var url = `${API_URL}/api/notifications/expired/?offset=0&limit=${PAGINATION_MAX}`;
 
         if (id) {
           url += `&listing=${id}`;


### PR DESCRIPTION
Refactors Notification to fetch the past store and notificaitons in a
method similar to active notifications.
Fixes skipped tests from loader modifications.
Solves store loading issues when making new listing notifications.
Fixes store loading issue when going from listing notification tab to
notification in mall management

AMLNG-857

**How to test**
Pull this branch. Check in listing modal > send notification
and in mall management > notifications