### PR TITLE
feat(listing management): Visual Indicator Disabled

### DIFF
--- a/app/js/components/listing/ListingTile.jsx
+++ b/app/js/components/listing/ListingTile.jsx
@@ -187,17 +187,17 @@ var AdminOwnerListingTile = React.createClass({
         var imageLargeUrl = listing.imageLargeUrl;
         if(this.props.listing.approvalStatus !== 'DELETED'){
             return (
-                <li className={'AdminOwnerListingTile'}>
+                <li className={(this.props.listing.approvalStatus !== "APPROVED" || !this.props.listing.isEnabled ) ? "AdminOwnerListingTile AdminOwnerListingTile--disabled " : "AdminOwnerListingTile"}>
                     { (this.props.listing.approvalStatus !== "DELETED")  &&
-                    <ActionMenu listing={listing} />
-                }
-                <a href={overview}>
-                    <img alt={`Click to manage ${listing.title}`} className="AdminOwnerListingTile__img" src={(this.props.listing.approvalStatus !== "DELETED") ? imageLargeUrl : deleted} />
-                    <span className="hidden-span">{listing.title}</span>
-                </a>
-                <InfoBar listing={listing} user={user}/>
-            </li>
-        );
+                        <ActionMenu listing={listing} />
+                    }
+                    <a href={overview}>
+                        <img alt={`Click to manage ${listing.title}`} className="AdminOwnerListingTile__img" src={(this.props.listing.approvalStatus !== "DELETED") ? imageLargeUrl : deleted} />
+                        <span className="hidden-span">{listing.title}</span>
+                    </a>
+                    <InfoBar listing={listing} user={user}/>
+                </li>
+            );
         }
         else{
             return (

--- a/app/js/components/listing/ListingTile.jsx
+++ b/app/js/components/listing/ListingTile.jsx
@@ -187,12 +187,12 @@ var AdminOwnerListingTile = React.createClass({
         var imageLargeUrl = listing.imageLargeUrl;
         if(this.props.listing.approvalStatus !== 'DELETED'){
             return (
-                <li className={(this.props.listing.approvalStatus !== "APPROVED" || !this.props.listing.isEnabled ) ? "AdminOwnerListingTile AdminOwnerListingTile--disabled " : "AdminOwnerListingTile"}>
+                <li className="AdminOwnerListingTile">
                     { (this.props.listing.approvalStatus !== "DELETED")  &&
                         <ActionMenu listing={listing} />
                     }
                     <a href={overview}>
-                        <img alt={`Click to manage ${listing.title}`} className="AdminOwnerListingTile__img" src={(this.props.listing.approvalStatus !== "DELETED") ? imageLargeUrl : deleted} />
+                        <img alt={`Click to manage ${listing.title}`} className={(this.props.listing.approvalStatus !== "APPROVED" || !this.props.listing.isEnabled ) ? "AdminOwnerListingTile__img AdminOwnerListingTile__img--disabled" : "AdminOwnerListingTile__img"} src={(this.props.listing.approvalStatus !== "DELETED") ? imageLargeUrl : deleted} />
                         <span className="hidden-span">{listing.title}</span>
                     </a>
                     <InfoBar listing={listing} user={user}/>

--- a/app/styles/listing/_admin-owner-listing-tile.scss
+++ b/app/styles/listing/_admin-owner-listing-tile.scss
@@ -10,6 +10,10 @@
     vertical-align: top;
 }
 
+.AdminOwnerListingTile--disabled{
+    opacity: 0.4;
+}
+
 .MyListings__listings.all .AdminOwnerListingTile,
 .MyListings__listings.IN_PROGRESS .AdminOwnerListingTile.draft,
 .MyListings__listings.REJECTED .AdminOwnerListingTile.needs-action,

--- a/app/styles/listing/_admin-owner-listing-tile.scss
+++ b/app/styles/listing/_admin-owner-listing-tile.scss
@@ -10,7 +10,7 @@
     vertical-align: top;
 }
 
-.AdminOwnerListingTile--disabled{
+.AdminOwnerListingTile__img--disabled{
     opacity: 0.4;
 }
 
@@ -82,7 +82,7 @@
 
 .AdminOwnerListingTile__actionMenu {
     position: absolute;
-
+    z-index: 1;
     top: 0px;
     right: 0px;
     border: none;


### PR DESCRIPTION
Makes disabled listings appear more opaque in this listing management
areas for better visual representation of what is enabled and disabled.

Closes #AMLNG-854

**Description**
As a user I would like a visual indication in Listing Management that a Listing is enabled or disabled.
Create and icon to display under a Listing in Listing Management if the listing is disabled.

**Acceptance Criteria**
- If a listing is disabled, an icon is visible under the Listing tile in the Listing Management Pages
- The icon does not replace the icon that indicated other status of the Listing, but is displayed near/next to that icon.

**How To Test**
Pull this branch. Go to Listing management. Disable a listing, it should be opaque. create a new listing and take it through the listing creation process. It Should be opaque until it is fully approved and enabled.