### PR TITLE
feat(listing management): add ability to sort list view

### DIFF
--- a/app/js/components/management/AllListings/index.jsx
+++ b/app/js/components/management/AllListings/index.jsx
@@ -67,6 +67,10 @@ var AllListings = React.createClass({
         });
     },
 
+    onSortChanged: function (sortOption) {
+        this.onFilterChanged('ordering', sortOption.searchParam);
+    },
+
     renderListings: function () {
         if (this.state.tableView === true) {
             return (
@@ -77,7 +81,8 @@ var AllListings = React.createClass({
         } else {
             return (
                 <LoadMore ref="loadMore" className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
-                    filter={this.state.filter} onCountsChanged={this.onCountsChanged}></LoadMore>
+                    filter={this.state.filter} onCountsChanged={this.onCountsChanged}
+                    onSortChanged={this.onSortChanged}></LoadMore>
             );
         }
     },

--- a/app/js/components/management/OrgListings/index.jsx
+++ b/app/js/components/management/OrgListings/index.jsx
@@ -70,6 +70,10 @@ var OrgListings = React.createClass({
         });
     },
 
+    onSortChanged: function (sortOption) {
+        this.onFilterChanged('ordering', sortOption.searchParam);
+    },
+
     componentWillReceiveProps: function(nextProps) {
         if (this.props.org && (this.props.org.name !== nextProps.org.name)) {
             this.onFilterChanged('org', nextProps.org.params.org);
@@ -86,7 +90,8 @@ var OrgListings = React.createClass({
         } else {
             return (
                 <LoadMore ref="loadMore" className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
-                    filter={this.state.filter} onCountsChanged={this.onCountsChanged}></LoadMore>
+                    filter={this.state.filter} onCountsChanged={this.onCountsChanged}
+                    onSortChanged={this.onSortChanged}></LoadMore>
             );
         }
     },

--- a/app/js/components/management/shared/LoadMore.jsx
+++ b/app/js/components/management/shared/LoadMore.jsx
@@ -101,7 +101,7 @@ var LoadMore = React.createClass({
         var children = this.generateChildren();
 
         if (children && children.length > 0 && !this.state.loadingError) {
-            return <ol className="list-unstyled">{ children }</ol>;
+            return <ol className="LoadMore__List list-unstyled">{ children }</ol>;
         }
         else if(!this.state.loading) {
             return <h5 style={{marginTop: "0"}}>No results found!</h5>;

--- a/app/js/components/management/shared/LoadMore.jsx
+++ b/app/js/components/management/shared/LoadMore.jsx
@@ -5,15 +5,24 @@ var ListingActions = require('../../../actions/ListingActions.js');
 
 var ListingTile = require('../../listing/ListingTile.jsx');
 var LoadIndicator = require('ozp-react-commons/components/LoadIndicator.jsx');
+var SelectBox = require('../../shared/SelectBox.jsx');
 var { UserRole } = require('ozp-react-commons/constants');
-
 
 var React = require('react');
 var Reflux = require('reflux');
 var { PropTypes } = React;
 
-var LoadMore = React.createClass({
+var sortOptions = [
+    {option: 'Last Modified', searchParam: '-edited_date'},
+    {option: 'Newest', searchParam: '-approved_date'},
+    {option: 'Title: A to Z', searchParam: 'title'},
+    {option: 'Title: Z to A', searchParam: '-title'},
+    {option: 'Rating: Low to High', searchParam: 'avg_rate, total_votes'},
+    {option: 'Rating: High to Low', searchParam: '-avg_rate, -total_votes'},
+    {option: 'Status', searchParam: 'approval_status'}
+];
 
+var LoadMore = React.createClass({
     mixins: [
         Reflux.listenTo(PaginatedListingsStore, 'onStoreChanged'),
         Reflux.listenTo(ListingActions.listingChangeCompleted, 'onListingChangeCompleted'),
@@ -22,21 +31,43 @@ var LoadMore = React.createClass({
 
     propTypes: {
         filter: PropTypes.object.isRequired,
-        onCountsChanged: PropTypes.func.isRequired
+        onCountsChanged: PropTypes.func.isRequired,
+        onSortChanged: PropTypes.func.isRequired
     },
 
     getInitialState: function () {
         return {
             listings: [],
             hasMore: false,
+            orderingText: this.state ? this.state.orderingText : 'Sort By',
             loading: true,
             loadingError: false
         };
     },
 
+    onSortChanged: function (order) {
+        var me = this;
+        var sortOption = null;
+
+        sortOptions.forEach(function(element) {
+            if (order == element.option) {
+                sortOption = element;
+            }
+        });
+
+        if(sortOption) {
+            this.setState({
+                orderingText: sortOption.option
+            });
+
+            this.props.onSortChanged(sortOption);
+        }
+    },
+
     render: function () {
         return this.transferPropsTo(
             <div className="LoadMore">
+                { this.renderSortOptions() }
                 { this.renderList() }
                 { (this.state.loading || this.state.loadingError) &&
                     <LoadIndicator showError={this.state.loadingError}
@@ -44,6 +75,25 @@ var LoadMore = React.createClass({
                 }
                 { this.renderLoadMoreButton() }
             </div>
+        );
+    },
+
+    renderSortOptions: function () {
+        if(this.state.tableView === true) {
+            return '';
+        }
+
+        var options = sortOptions.map((option) => {
+            return <option key={option.option} className="sortBy" value={option.option}>
+                {option.option}
+            </option>;
+        });
+
+        return (
+            <SelectBox className="SelectBox sortBy" label={this.state.orderingText}
+                onChange={this.onSortChanged}>
+                { options }
+            </SelectBox>
         );
     },
 

--- a/app/js/components/management/user/MyListings.jsx
+++ b/app/js/components/management/user/MyListings.jsx
@@ -65,6 +65,10 @@ var MyListings = React.createClass({
         });
     },
 
+    onSortChanged: function (sortOption) {
+        this.onFilterChanged('ordering', sortOption.searchParam);
+    },
+
     addOwnerToFilter: function(){
         var profile = SelfStore.getDefaultData().currentUser;
         this.state.filter['owners_id'] = profile.id;
@@ -83,7 +87,8 @@ var MyListings = React.createClass({
         } else {
             return (
                 <LoadMore ref="loadMore" className="ListingsManagement__LoadMore col-xs-9 col-lg-10 all"
-                    filter={this.state.filter} onCountsChanged={this.onCountsChanged}></LoadMore>
+                    filter={this.state.filter} onCountsChanged={this.onCountsChanged}
+                    onSortChanged={this.onSortChanged}></LoadMore>
                 );
             }
         },

--- a/app/styles/_discovery.scss
+++ b/app/styles/_discovery.scss
@@ -132,66 +132,6 @@
         min-height: 500px;
     }
 
-    .sortBy {
-        border: 1px solid #dbdcdd;
-        width: 190px;
-        border-radius: 0;
-        box-shadow: none;
-        height:27px;
-        float: right;
-        display: inline-block;
-        top: 5px;
-
-        > button {
-            padding-top: 4px;
-            height: 27px;
-        }
-
-        > .react-select-box {
-
-            > .react-select-box-label {
-                font-size: inherit;
-                font-weight: 400;
-                line-height: 19px;
-                color: $gray-dark;
-
-                & .react-select-box-empty {
-                    color: $gray-dark;
-                }
-            }
-        }
-
-        > .react-select-box::after {
-            top: 8px;
-        }
-
-        > .react-select-box-options {
-            margin: 0;
-            border-radius: 0;
-            box-shadow: none;
-            border: 0;
-            background: $gray-lightest;
-            width: 100%;
-
-            &:focus {
-                outline: none;
-            }
-        }
-
-        > .react-select-box-clear {
-            top: 20px;
-            background-color: $white;
-
-            &:before{
-                background-color: transparent;
-                @extend .icon-cross-14-grayDark;
-                content: ' ';
-            }
-
-        }
-
-    }
-
     .resultsDiv {
         display: inline-block;
         position: relative;

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -494,3 +494,63 @@ $icons: (
 .rating-text {
     font-size: 12px;
 }
+
+.SelectBox.sortBy {
+    border: 1px solid #dbdcdd;
+    width: 190px;
+    border-radius: 0;
+    box-shadow: none;
+    height:27px;
+    float: right;
+    display: inline-block;
+    top: 5px;
+
+    > button {
+        padding-top: 4px;
+        height: 27px;
+    }
+
+    > .react-select-box {
+
+        > .react-select-box-label {
+            font-size: inherit;
+            font-weight: 400;
+            line-height: 19px;
+            color: $gray-dark;
+
+            & .react-select-box-empty {
+                color: $gray-dark;
+            }
+        }
+    }
+
+    > .react-select-box::after {
+        top: 8px;
+    }
+
+    > .react-select-box-options {
+        margin: 0;
+        border-radius: 0;
+        box-shadow: none;
+        border: 0;
+        background: $gray-lightest;
+        width: 100%;
+
+        &:focus {
+            outline: none;
+        }
+    }
+
+    > .react-select-box-clear {
+        top: 20px;
+        background-color: $white;
+
+        &:before{
+            background-color: transparent;
+            @extend .icon-cross-14-grayDark;
+            content: ' ';
+        }
+
+    }
+
+}

--- a/app/styles/management/listings/_listings.scss
+++ b/app/styles/management/listings/_listings.scss
@@ -7,7 +7,7 @@
         top: -15px;
     }
 
-    .list-unstyled {
+    .LoadMore__List {
         margin-top: 30px;
     }
 

--- a/app/styles/management/listings/_listings.scss
+++ b/app/styles/management/listings/_listings.scss
@@ -2,7 +2,15 @@
     padding: 30px;
     background: $white;
     min-height: 500px;
-    
+
+    .SelectBox.sortBy {
+        top: -15px;
+    }
+
+    .list-unstyled {
+        margin-top: 30px;
+    }
+
     .AdminOwnerListingTile {
         display: inline-block;
     }


### PR DESCRIPTION
AMLNG-858

**Description**     
As a user, I would like all Listing Management tabs to have sort order dropdown option to reorder results and the default sort order to be last modified.

**Acceptance Criteria**   
- when a user clicks on sub tab all results will have the same sort order
- sort order will be last modified
- each tab will have sort order dropdown option to reorder results

For now, the sort options are Last Modified, Newest, Title: A to Z, Title: Z to A, Rating: Low to High, Rating: High to Low, Status.  If no sort option is selected, the backend sort defaults to last modified.
 
**How to test code**    
Pull `listing_default_sort` from ozp-backend
Pull `listing_mgmt_sortable_grid` from ozp-center

Go to Listing Management
Verify Acceptance Criteria on the list view of both the All Center Listings and My Listings tabs