### PR TITLE
feat(loading messages): display loading message for long running back-end tasks

### DIFF
--- a/app/js/actions/NotificationActions.js
+++ b/app/js/actions/NotificationActions.js
@@ -5,15 +5,57 @@ var createActions = require('../utils/createActions');
 var NotificationApi = require('../webapi/Notification.js');
 var ProfileActions = require('ozp-react-commons/actions/ProfileActions');
 
+var MessageStore = require('../stores/MessageStore');
+
+var _notificationTypes = [
+    {key: 'System', value: 'System'},
+    {key: 'StewardAppNotification', value: 'Update Request'}
+];
+
 var NotificationActions = createActions({
 
     createNotification(uuid, notification) {
+        var displayType = ' ';
+        if(_.has(notification, 'listing')) {
+            displayType = ' Listing ';
+        }
+        else {
+            var notificationType = _.find(_notificationTypes, { key: notification.notificationType });
+            if(notificationType) {
+                displayType = ' ' + notificationType['value'] + ' ';
+            }
+        }
+        var messageData = MessageStore.addMessage('Sending' + displayType + 'Notification', true);
+
         NotificationApi.create(notification)
             .then(function (response) {
                 NotificationActions.createNotificationCompleted(uuid, response);
+                MessageStore.updateMessage(messageData['uuid'], {
+                    message: messageData['message'] + ' Complete!',
+                    state: MessageStore.SUCCESS_STATE,
+                    hidden: false
+                });
                 ProfileActions.fetchNotifications();
             })
-            .fail(_.partial(NotificationActions.createNotificationFailed, uuid));
+            .fail(function (response) {
+                NotificationActions.createNotificationFailed(uuid, response);
+
+                // if readyState is 0, the failure is caused by a window unload
+                // (navigating away from the page, forcing an app reload)
+                if(response.readyState == 0) {
+                    MessageStore.updateMessage(messageData['uuid'], {
+                        message: messageData['message'] + ' (message out-of-sync due to page reload)',
+                        hidden: true
+                    });
+                }
+                else {
+                    MessageStore.updateMessage(messageData['uuid'], {
+                        message: messageData['message'] + ' Failed!',
+                        state: MessageStore.ERROR_STATE,
+                        hidden: false
+                    });
+                }
+            });
     },
 
     expireNotification(notification) {

--- a/app/js/components/app.jsx
+++ b/app/js/components/app.jsx
@@ -16,6 +16,7 @@ var NotificationWindow = require('./notification/NotificationWindow.jsx');
 var { ListingDeleteConfirmation } = require('./shared/DeleteConfirmation.jsx');
 var { ListingPendingDeleteConfirmation } = require('./shared/PendingDeleteConfirmation.jsx');
 var { ListingUndeleteConfirmation } = require('./shared/UndeleteConfirmation.jsx');
+var MessageQueue = require('./shared/MessageQueue.jsx');
 var TagSubscriptionActions = require('ozp-react-commons/actions/TagSubscriptionActions');
 var TagSubscriptionStore = require('ozp-react-commons/stores/TagSubscriptionStore');
 var CategorySubscriptionActions = require('ozp-react-commons/actions/CategorySubscriptionActions');
@@ -31,6 +32,7 @@ var App = React.createClass({
             <div id="App">
                 <RouteHandler system={this.state.system} currentUser={this.state.currentUser} {...this.props} />
                 { this.renderModal() }
+                <MessageQueue/>
             </div>
         );
     },

--- a/app/js/components/management/mall/notifications/CreateNotification.jsx
+++ b/app/js/components/management/mall/notifications/CreateNotification.jsx
@@ -32,6 +32,8 @@ var CreateNotification = React.createClass({
     },
 
     getInitialState() {
+        var loadingState = this.getLoadingState();
+
         return {
             uuid: uuid(),
             date: null,
@@ -39,8 +41,9 @@ var CreateNotification = React.createClass({
             hour: '00',
             minute: '00',
             type: 'System',
-            loading: false,
-            loadingError: false
+            loading: loadingState.loading,
+            loadingError: loadingState.loadingError,
+            errorMessage: loadingState.errorMessage
         };
     },
 
@@ -81,10 +84,12 @@ var CreateNotification = React.createClass({
         var expiresDate = new Date(
             Date.UTC(date.year(), date.month(), date.date(), parseInt(hour, 10), parseInt(minute, 10))
         );
+        var displayType = _.find(this.props.types, { key: type });
 
-        this.setState({
+        this.updateLoadingState({
             loading: true,
-            loadingError: false
+            loadingError: false,
+            errorMessage: "Error Creating " + displayType['value'] + " Notification ('" + message + "' set to expire on " + expiresDate.toString() + ")"
         });
 
         NotificationActions.createNotification(this.state.uuid, {
@@ -96,21 +101,49 @@ var CreateNotification = React.createClass({
 
     /* eslint-disable no-unused-vars */
     onNotificationCreated(uuid, notification) {
-        this.setState({
+        this.updateLoadingState({
             loading: false,
             loadingError: false
         });
+
         if (this.state.uuid === uuid) {
             this.onReset();
         }
     },
     /* eslint-enable no-unused-vars */
 
-    onNotificationCreateFailed() {
-        this.setState({
+    onNotificationCreateFailed(uuid, response) {
+        // if readyState is 0, the failure is caused by a window unload
+        // (navigating away from the page, forcing an app reload)
+        this.updateLoadingState({
             loading: false,
-            loadingError: true
+            loadingError: response.readyState != 0
         });
+    },
+
+    getLoadingState() {
+        var storageData = JSON.parse(sessionStorage.getItem('create-notification-loading-data'));
+
+        if(!storageData) {
+            return {
+                loading: false,
+                loadingError: false
+            };
+        }
+
+        return storageData;
+    },
+
+    updateLoadingState(loadingData) {
+        var storageData = this.getLoadingState();
+
+        storageData.loading = _.has(loadingData, 'loading') ? loadingData.loading : storageData.loading;
+        storageData.loadingError = _.has(loadingData, 'loadingError') ? loadingData.loadingError : storageData.loadingError;
+        storageData.errorMessage = _.has(loadingData, 'errorMessage') ? loadingData.errorMessage : storageData.errorMessage;
+
+        sessionStorage.setItem('create-notification-loading-data', JSON.stringify(storageData));
+
+        this.setState(storageData);
     },
 
     render() {
@@ -169,7 +202,8 @@ var CreateNotification = React.createClass({
                     { (this.state.loading || this.state.loadingError) &&
                         <div>
                             <LoadIndicator showError={this.state.loadingError}
-                                errorMessage="Error Creating Notification"
+                                message="Sending notification.  This process may take a few minutes."
+                                errorMessage={this.state.errorMessage || "Error Creating Notification"}
                             />
                         </div>
                     }

--- a/app/js/components/shared/MessageQueue.jsx
+++ b/app/js/components/shared/MessageQueue.jsx
@@ -1,0 +1,38 @@
+'use strict';
+
+var React = require('react');
+var Reflux = require('reflux');
+
+var MessageStore = require('../../stores/MessageStore');
+
+var MessageQueueItem = require('./MessageQueueItem.jsx');
+
+var MessageQueue = React.createClass({
+    mixins: [
+        Reflux.listenTo(MessageStore, 'onStoreChange')
+    ],
+
+    getInitialState() {
+        return {
+            messages: MessageStore.getMessages()
+        }
+    },
+
+    onStoreChange() {
+        this.setState(this.getInitialState());
+    },
+
+    render() {
+        var messageItems = this.state.messages.map(m =>
+            <MessageQueueItem message={m} key={m.uuid}/>
+        );
+
+        return (
+            <div className="message-queue navbar-fixed-bottom">
+                {messageItems}
+            </div>
+        );
+    }
+});
+
+module.exports = MessageQueue;

--- a/app/js/components/shared/MessageQueueItem.jsx
+++ b/app/js/components/shared/MessageQueueItem.jsx
@@ -1,0 +1,96 @@
+'use strict';
+
+var React = require('react');
+
+var MessageStore = require('../../stores/MessageStore');
+
+var _Date = require('ozp-react-commons/components/Date.jsx');
+var Time = require('ozp-react-commons/components/Time.jsx');
+
+// map of message ID --> timer/timeout for message close/delete countdown
+var timers = {};
+var timeouts = {};
+
+var MessageQueueItem = React.createClass({
+    propTypes: {
+        message: React.PropTypes.object.isRequired
+    },
+
+    getInitialState() {
+        return {
+            showTimeout: false,
+            timeLeft: 10    // initial countdown for message
+        }
+    },
+
+    componentWillReceiveProps(nextProps) {
+        if(nextProps.message.state == MessageStore.SUCCESS_STATE) {
+            var me = this;
+
+            if(!timeouts[nextProps.message.uuid]) {
+                timeouts[nextProps.message.uuid] = setTimeout(function() {
+                    MessageStore.deleteMessage(nextProps.message.uuid);
+                }, me.state.timeLeft * 1000);
+            }
+
+            if(!timers[nextProps.message.uuid]) {
+                timers[nextProps.message.uuid] = setInterval(function() {
+                    if(me.state.timeLeft <= 0) {
+                        clearInterval(timers[nextProps.message.uuid]);
+                        timers[nextProps.message.uuid] = null;
+                    }
+                    else if(me.isMounted()) {
+                        me.setState({ timeLeft: me.state.timeLeft - 1 });
+                    }
+                }, 1000);
+            }
+
+            this.setState({ showTimeout: true });
+        }
+    },
+
+    componentWillUnmount() {
+        if(timeouts[this.props.message.uuid]) {
+            clearTimeout(timeouts[this.props.message.uuid]);
+            timeouts[this.props.message.uuid] = null;
+        }
+
+        if(timers[this.props.message.uuid]) {
+            clearInterval(timers[this.props.message.uuid]);
+            timers[this.props.message.uuid] = null;
+        }
+    },
+
+    onHideClick() {
+        if(this.props.message.state != MessageStore.PROGRESS_STATE) {
+            MessageStore.deleteMessage(this.props.message.uuid);
+        }
+        else {
+            MessageStore.updateMessage(this.props.message.uuid, { hidden: true });
+        }
+    },
+
+    render() {
+        if(this.props.message.hidden) {
+            return (null);
+        }
+
+        return (
+            <div className={"message-item alert alert-" + this.props.message.state}>
+                <span className="message">{this.props.message.message}</span>
+                <span className="timestamp">
+                    <_Date date={this.props.message.createdDate}/>
+                    <Time date={this.props.message.createdDate}/>
+                </span>
+                <button type="button" className="hide-button pull-right" onClick={this.onHideClick}>
+                    <i className="icon-cross-16"></i>
+                </button>
+                { this.state.showTimeout &&
+                    <p>This message will close automatically in {this.state.timeLeft} second{this.state.timeLeft == 1 ? '' : 's'}...</p>
+                }
+            </div>
+        );
+    }
+});
+
+module.exports = MessageQueueItem;

--- a/app/js/stores/MessageStore.js
+++ b/app/js/stores/MessageStore.js
@@ -1,0 +1,109 @@
+'use strict';
+
+var Reflux = require('reflux');
+var uuid = require('../utils/uuid.js');
+var _ = require('../utils/_');
+
+var _storageKey = 'message-queue';
+
+var MessageStore = Reflux.createStore({
+    PROGRESS_STATE: 'info',
+    ERROR_STATE: 'danger',
+    SUCCESS_STATE: 'success',
+
+    data: {
+        messages: []
+    },
+
+    init: function () {
+        this._initMessages();
+    },
+
+    addMessage(message, useStorage) {
+        var data = {
+            'uuid': uuid(),
+            'message': message,
+            'state': this.PROGRESS_STATE,
+            'hidden': false,
+            'createdDate': new Date()
+        };
+
+        this.data.messages.push(data);
+
+        if(useStorage) {
+            var storageMessages = JSON.parse(sessionStorage.getItem(_storageKey));
+
+            storageMessages.push(data);
+            sessionStorage.setItem(_storageKey, JSON.stringify(storageMessages));
+        }
+
+        var finishedMessages = _.filter(this.data.messages, m => m.state != this.PROGRESS_STATE);
+        finishedMessages.forEach(m => {
+            this.deleteMessage(m.uuid);
+        });
+
+        this.trigger();
+
+        return data;
+    },
+
+    updateMessage(id, newData) {
+        var message = _.find(this.data.messages, { uuid: id });
+
+        if(message) {
+            message.message = _.has(newData, 'message') ? newData.message : message.message;
+            message.state = _.has(newData, 'state') ? newData.state : message.state;
+            message.hidden = _.has(newData, 'hidden') ? newData.hidden : message.hidden;
+
+            var storageMessages = JSON.parse(sessionStorage.getItem(_storageKey));
+            var storageIndex = _.findIndex(storageMessages, { uuid: id });
+
+            if(storageIndex > -1) {
+                storageMessages[storageIndex] = message;
+                sessionStorage.setItem(_storageKey, JSON.stringify(storageMessages));
+            }
+
+            this.trigger();
+        }
+    },
+
+    deleteMessage(id) {
+        var removedMessages = _.remove(this.data.messages, { uuid: id });
+
+        var storageMessages = JSON.parse(sessionStorage.getItem(_storageKey));
+        var removedStorageMessages = _.remove(storageMessages, { uuid: id });
+
+        if(removedStorageMessages.length > 0) {
+            sessionStorage.setItem(_storageKey, JSON.stringify(storageMessages));
+        }
+
+        if(removedMessages.length > 0 || removedStorageMessages.length > 0) {
+            this.trigger();
+        }
+    },
+
+    getMessages() {
+        var sortedMessages = this.data.messages.sort((a, b) => a.createdDate < b.createdDate);
+
+        return sortedMessages;
+    },
+
+    _initMessages() {
+        this.data.messages = JSON.parse(sessionStorage.getItem(_storageKey));
+
+        if(this.data.messages == null) {
+            sessionStorage.setItem(_storageKey, JSON.stringify([]));
+            this.data.messages = [];
+        }
+
+        // JSON parser doesn't parse dates appropriately
+        this.data.messages.forEach(m => {
+            m.createdDate = new Date(m.createdDate);
+        });
+
+        this.trigger();
+    }
+
+});
+
+module.exports = MessageStore;

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -554,3 +554,30 @@ $icons: (
     }
 
 }
+
+.message-queue {
+    z-index: 1060;
+
+    .message-item {
+        max-width: 520px;
+        margin: 0 auto 20px auto;
+
+        .message {
+            font-weight: bold;
+        }
+
+        .timestamp span {
+            padding-left: 10px;
+        }
+    }
+
+    .hide-button {
+        background: none;
+        border: none;
+        padding-left: 10px;
+    }
+
+    .icon-cross-16 {
+        background-position: 89.42% 35.58%;
+    }
+}


### PR DESCRIPTION
closes AMLNG-863

**Description**
As a user, I would like to receive feedback when I send a notification, especially long-running system notifications.  When I send a notification, I would like to know that the request is being processed and what the outcome (success / failure) is.

**Acceptance Criteria**
- when the user sends a notification, the UI displays a message indicator informing the user of his/her action
- when the notification is successfully sent to all desired users or fails to be sent, the message indicator updates accordingly
- the user has the ability to hide the indicator in the UI

**How to Test**
Pull `notification_indicator` from `ozp-center`

It may be helpful to update the backend to simulate long notification requests and errors.  To do this, modify the file `ozp-backend/ozpcenter/api/notification/views.py`.  Add the following to the beginning of the `create` function of `class NotificationViewSet`:

```
    def create(self, request):
        import time

        # simulate 10 second notification
        time.sleep(10)

        # simulate getting an error
        raise Exception()

        # rest of the create function remains the same
        ...
```
  
  