### PR TITLE
fix(profile): fix bugs in HUD profile window

### DIFF
--- a/app/js/components/management/mall/notifications/CreateNotification.jsx
+++ b/app/js/components/management/mall/notifications/CreateNotification.jsx
@@ -167,11 +167,9 @@ var CreateNotification = React.createClass({
                         </button>
                     </div>
                     { (this.state.loading || this.state.loadingError) &&
-                        <div>
-                            <LoadIndicator showError={this.state.loadingError}
-                                errorMessage="Error Creating Notification"
-                            />
-                        </div>
+                        <LoadIndicator showError={this.state.loadingError}
+                            errorMessage="Error Creating Notification"
+                        />
                     }
                 </form>
             </div>

--- a/app/styles/_discovery.scss
+++ b/app/styles/_discovery.scss
@@ -175,38 +175,3 @@
         margin: unset;
     }
 }
-
-.loader {
-    margin: 0 auto;
-    display: block;
-}
-
-.loader-title {
-    text-align: center;
-}
-
-.loader-message {
-    text-align: center;
-}
-
-.loader-animate {
-    -animation: spin .9s infinite linear;
-    -ms-animation: spin2 .9s infinite linear;
-    -moz-animation: spin2 .9s infinite linear;
-    -webkit-animation: spin2 .9s infinite linear;
-}
-
-@-webkit-keyframes spin2 {
-    from { -webkit-transform: rotate(0deg);}
-    to { -webkit-transform: rotate(360deg);}
-}
-
-@keyframes spin {
-    from { transform: scale(1) rotate(0deg);}
-    to { transform: scale(1) rotate(360deg);}
-}
-
-@keyframes spin2 {
-    from { transform: scale(1) rotate(0deg);}
-    to { transform: scale(1) rotate(360deg);}
-}


### PR DESCRIPTION
**Description**

Fix bugs in the profile window on the HUD page.  These bugs are not present when opening the profile on the Center page.

**Acceptance Criteria**

Open the profile window in HUD:
1) Ensure that when loading listings, the spinner icon is centered and animates
2) Ensure that all profile information, including settings and subscriptions, are visible in the window.

Note that you can compare the HUD profile to the correctly working Center profile.  If you spot any differences, then there is a bug/issue.

**How to Test Code**

Pull `fix_profile` from `ozp-center`
Pull `fix_profile` from `ozp-hud`
Pull `fix_profile` from `ozp-react-commons`

Update `package.json` in HUD and Center to point to this branch or your local `ozp-react-commons` repo