### PR TITLE
fix(listing management): use org short name instead of titles for URLs

### DIFF
--- a/app/js/components/management/OrgListings/index.jsx
+++ b/app/js/components/management/OrgListings/index.jsx
@@ -28,14 +28,18 @@ var OrgListings = React.createClass({
 
     getInitialState: function () {
         var useTableView = JSON.parse(sessionStorage.getItem('center-orgListings-toggleView'));
+        var filter = {};
         if (!this.props.org) {
             this.props.org = null;
         }
+        else {
+            filter = _.assign(this.getQuery(), {
+                org: this.props.org.params.org
+            });
+        }
         return {
             counts: {},
-            filter: _.assign(this.getQuery(), {
-                org: this.props.org.params.org
-            }),
+            filter: filter,
             tableView: useTableView
         };
     },

--- a/app/js/components/management/user/RecentActivitySidebar.jsx
+++ b/app/js/components/management/user/RecentActivitySidebar.jsx
@@ -113,7 +113,7 @@ var OrgListingsSidebarFilter = React.createClass({
     render: function () {
         return (
             <RadioGroup name="recent-activity-org-listings" onChange={this.props.handleChange}>
-                <Link id="recent-activity-pending" to="org-listings" query={{approval_status: "PENDING"}} params={{org: this.props.org.title}}>
+                <Link id="recent-activity-pending" to="org-listings" query={{approval_status: "PENDING"}} params={{org: this.props.org.shortName}}>
                     <label htmlFor="recent-activity-org-pending" className="label-needs-action">
                         <ApprovalStatusIcons definedStatus={"PENDING"} userType={"orgSteward"}/>
                         Pending { this.props.org.shortName } Review
@@ -121,7 +121,7 @@ var OrgListingsSidebarFilter = React.createClass({
                     </label>
                 </Link>
 
-                <Link id="recent-activity-pending" to="org-listings" query={{approval_status: "APPROVED_ORG"}} params={{org: this.props.org.title}}>
+                <Link id="recent-activity-pending" to="org-listings" query={{approval_status: "APPROVED_ORG"}} params={{org: this.props.org.shortName}}>
                     <label htmlFor="recent-activity-org-pending" className="label-pending">
                         <ApprovalStatusIcons definedStatus={"APPROVED_ORG"}/>
                         Organization Approved
@@ -129,7 +129,7 @@ var OrgListingsSidebarFilter = React.createClass({
                     </label>
                 </Link>
 
-                <Link id="recent-activity-published" to="org-listings" query={{approval_status: "APPROVED"}} params={{org: this.props.org.title}}>
+                <Link id="recent-activity-published" to="org-listings" query={{approval_status: "APPROVED"}} params={{org: this.props.org.shortName}}>
                     <label htmlFor="recent-activity-org-published" className="label-published">
                         <ApprovalStatusIcons definedStatus={"APPROVED"}/>
                         Published
@@ -137,7 +137,7 @@ var OrgListingsSidebarFilter = React.createClass({
                     </label>
                 </Link>
 
-                <Link id="recent-activity-returned" to="org-listings" query={{approval_status: "REJECTED"}} params={{org: this.props.org.title}}>
+                <Link id="recent-activity-returned" to="org-listings" query={{approval_status: "REJECTED"}} params={{org: this.props.org.shortName}}>
                     <label htmlFor="recent-activity-org-returned" className="label-rejected">
                         <ApprovalStatusIcons definedStatus={"REJECTED"}/>
                         Returned to Owner
@@ -145,7 +145,7 @@ var OrgListingsSidebarFilter = React.createClass({
                     </label>
                 </Link>
 
-                <Link id="recent-activity-deleted" to="org-listings" query={{approval_status: "DELETED"}} params={{org: this.props.org.title}}>
+                <Link id="recent-activity-deleted" to="org-listings" query={{approval_status: "DELETED"}} params={{org: this.props.org.shortName}}>
                     <label htmlFor="recent-activity-org-deleted" className="label-deleted">
                         <ApprovalStatusIcons definedStatus={"DELETED"}/>
                         Deleted
@@ -153,7 +153,7 @@ var OrgListingsSidebarFilter = React.createClass({
                     </label>
                 </Link>
 
-                <Link id="recent-activity-pending-deletion" to="org-listings" query={{approval_status: "PENDING_DELETION"}} params={{org: this.props.org.title}}>
+                <Link id="recent-activity-pending-deletion" to="org-listings" query={{approval_status: "PENDING_DELETION"}} params={{org: this.props.org.shortName}}>
                     <label htmlFor="recent-activity-org-pending-deletion" className="label-pending-deletion">
                         <i className="icon-caret-right"></i>
                         Pending Deletion

--- a/app/js/components/management/user/index.jsx
+++ b/app/js/components/management/user/index.jsx
@@ -54,7 +54,7 @@ var ListingManagement = React.createClass({
                     to: 'org-listings',
                     name: org.title + ' Listings',
                     params: {
-                        org: org.title
+                        org: org.shortName
                     }
                 });
             });

--- a/app/js/mixins/UserRoleMixin.js
+++ b/app/js/mixins/UserRoleMixin.js
@@ -33,7 +33,7 @@ var OrgSteward = {
             var { org } = params;
             if (org){
                 var organization = SystemStore.getSystem().organizations.filter(function(organization) {
-                    return organization.title === org;
+                    return organization.shortName === org;
                 })[0];
                 if (organization == undefined){
                     organization = org;


### PR DESCRIPTION
AMLNG-801

**Description**
When I look at an org's listing, the URL contains the organization's title. Instead, it should use the organization's short name to prevent spaces in the URL.

**Acceptance Criteria**
Log in as an Org Steward (ie julia)
Go to Listing Management
Select a tab corresponding to an organization

1) Ensure the URL contains the org's short name instead of the title
2) Ensure the listings are filtered by org appropriately and the counts are correct (both table and grid views). Test sidebar filters too.
3) Ensure that getting to the tab automatically (ie via the Recent Activity Sidebar filters) follows 1-2 as well.

Manually change the URL as follows:

4) Changing the URL from org short name to org title gives an unauthorized alert message and redirects to the Center homepage.
5) Trying to access an org that the logged in user doesn't have permission to see also is unauthorized
6) Entering "garbage" or blank input also is unauthorized. In the case of blank input, it simply redirects.

**How to test code**
Pull `org_listing_shortname` from `ozp-backend`
Pull `org_listing_shortname` from `ozp-center`