### PR TITLE
fix(listing management): make toggling between list and table view consistent through all tabs

### DIFF
--- a/app/js/components/management/AllListings/index.jsx
+++ b/app/js/components/management/AllListings/index.jsx
@@ -27,7 +27,7 @@ var AllListings = React.createClass({
     ],
 
     getInitialState: function () {
-        var useTableView = JSON.parse(sessionStorage.getItem('center-allListings-toggleView'));
+        var useTableView = JSON.parse(sessionStorage.getItem('center-listings-toggleView'));
         return {
             counts: {},
             filter: this.getQuery(),
@@ -55,7 +55,7 @@ var AllListings = React.createClass({
 
     onViewToggle: function (event) {
         event.preventDefault();
-        sessionStorage.setItem("center-allListings-toggleView", !this.state.tableView);
+        sessionStorage.setItem("center-listings-toggleView", !this.state.tableView);
         this.setState({
             tableView: !this.state.tableView
         });

--- a/app/js/components/management/OrgListings/index.jsx
+++ b/app/js/components/management/OrgListings/index.jsx
@@ -27,7 +27,7 @@ var OrgListings = React.createClass({
     ],
 
     getInitialState: function () {
-        var useTableView = JSON.parse(sessionStorage.getItem('center-orgListings-toggleView'));
+        var useTableView = JSON.parse(sessionStorage.getItem('center-listings-toggleView'));
         var filter = {};
         if (!this.props.org) {
             this.props.org = null;
@@ -62,7 +62,7 @@ var OrgListings = React.createClass({
 
     onViewToggle: function (event) {
         event.preventDefault();
-        sessionStorage.setItem("center-orgListings-toggleView", !this.state.tableView);
+        sessionStorage.setItem("center-listings-toggleView", !this.state.tableView);
         this.setState({
             tableView: !this.state.tableView
         });

--- a/app/js/components/management/__tests__/AllListings-test.js
+++ b/app/js/components/management/__tests__/AllListings-test.js
@@ -17,7 +17,7 @@ describe ('AllListings', function () {
 
     beforeEach( function () {
         ProfileMock.mockAdmin("Test Organization");
-        sessionStorage.setItem("center-allListings-toggleView", false);
+        sessionStorage.setItem("center-listings-toggleView", false);
         router = Router.run(routes, location, function (Handler) {
             listingManagement = TestUtils.renderIntoDocument(
                 <Handler/>

--- a/app/js/components/management/__tests__/OrgListings-test.js
+++ b/app/js/components/management/__tests__/OrgListings-test.js
@@ -25,7 +25,7 @@ describe ('OrgListings', function () {
 
     beforeEach( function () {
         ProfileMock.mockOrgSteward(mockOrg);
-        sessionStorage.setItem("center-orgListings-toggleView", false);
+        sessionStorage.setItem("center-listings-toggleView", false);
         router = Router.run(routes, location, function (Handler) {
             listingManagement = TestUtils.renderIntoDocument(
                 <Handler org={mockOrg}/>

--- a/app/js/components/management/user/MyListings.jsx
+++ b/app/js/components/management/user/MyListings.jsx
@@ -25,7 +25,7 @@ var MyListings = React.createClass({
     },
 
     getInitialState: function () {
-        var useTableView = JSON.parse(sessionStorage.getItem('myListings-toggleView'));
+        var useTableView = JSON.parse(sessionStorage.getItem('center-listings-toggleView'));
         return {
             counts: {},
             filter: this.getQuery(),
@@ -53,7 +53,7 @@ var MyListings = React.createClass({
 
     onViewToggle: function (event) {
         event.preventDefault();
-        sessionStorage.setItem("myListings-toggleView", !this.state.tableView);
+        sessionStorage.setItem("center-listings-toggleView", !this.state.tableView);
         this.setState({
             tableView: !this.state.tableView
         });


### PR DESCRIPTION
closes AMLNG-892

**Description**
In listing management, when a user toggles between list view and grid view, their state is not always preserved across tabs

**Acceptance Criteria**
Log in as an Org Steward (ie julia) -- you can test with a variety of users, but make sure to test with at least one org steward that has an org listing tab
Go to Listing Management
Toggle between list and table view
RESULTS: Changing tabs does not preserve the list/table view selection
EXPECTED RESULTS: Changing tabs preserves the list/table view selection

**How to Test Code**
Pull `inconsistent_state_fix` from `ozp-center`