### PR TITLE
fix(listing management): deleting a listing correctly updates the table view

### DIFF
--- a/app/js/components/carousel/index.jsx
+++ b/app/js/components/carousel/index.jsx
@@ -126,7 +126,7 @@ var Carousel = React.createClass({
         );
 
         return (
-            <div className="carousel" onResize={() => console.log('resized!')}>
+            <div className="carousel">
                 {showArrows ?
                     <div>
                         {items.length === 1 ?

--- a/app/js/components/management/shared/TableView.jsx
+++ b/app/js/components/management/shared/TableView.jsx
@@ -383,15 +383,14 @@ var TableView = React.createClass({
         }
 
         this.props.onCountsChanged(counts);
-
-        // TODO: Figure out better way for counts updating
-        ListingApi.getAllListings(undefined, this.props.filter).then(function (response){
-            me.props.onCountsChanged(response._response.counts);
-        });
     },
 
     onListingChangeCompleted: function () {
-        this.onStoreChanged();
+        this.props.filter.offset = 0;
+        this.offset = 0;
+
+        // trigger a store refresh to sync table info/counts with listing change
+        UnpaginatedListingsStore.filterChange(this.props.filter);
     },
 
     onFetchAllListingsAtOnce: function () {

--- a/app/js/stores/UnpaginatedListingsStore.js
+++ b/app/js/stores/UnpaginatedListingsStore.js
@@ -41,20 +41,9 @@ var UnpaginatedListingsStore = Reflux.createStore({
     },
 
     onListingChangeCompleted: function (data) {
-        var dataChanged = false;
-        for (var key in _unpaginatedListByFilter){
-            var list = _unpaginatedListByFilter[key].data;
-            for (var listing in list){
-                var entry = list[listing];
-                if (entry.id == data.id){
-                    list[listing] = data;
-                    dataChanged = true;
-                }
-            }
-        }
-        if(dataChanged) {
-            this.trigger();
-        }
+        // clear all cached results
+        _unpaginatedListByFilter = {};
+        this.trigger();
     },
 
     filterChange: function (filter) {


### PR DESCRIPTION
closes AMLNG-891

**Description**
In listing management, when a user deletes a listing while in table view, the listing still shows up in the list, even if the status filter is not set to Deleted.  The listing is displayed as deleted, but should not be a part of the list.

**Acceptance Criteria**
Go to Listing Management
Toggle to show the table view
Set the sidebar filter to "Published"
Delete a listing from the table view
RESULTS: Listing displayed as deleted, but shows up in the list
EXPECTED RESULTS: Listing is no longer a part of the "Published" filter and is in the "Deleted" filter

**How to Test Code**
Pull `pending_delete_fix` from `ozp-center`