### PR TITLE
Fix carousel style again

### DIFF
--- a/app/styles/_carousel.scss
+++ b/app/styles/_carousel.scss
@@ -32,6 +32,7 @@ ul {
 }
 
 .carousel__slides {
+    display: inline-flex;
     display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
     display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
     display: -ms-flexbox;      /* TWEENER - IE 10 */

--- a/app/styles/_carousel.scss
+++ b/app/styles/_carousel.scss
@@ -32,7 +32,11 @@ ul {
 }
 
 .carousel__slides {
-    display: inline-flex;
+    display: -webkit-box;      /* OLD - iOS 6-, Safari 3.1-6 */
+    display: -moz-box;         /* OLD - Firefox 19- (buggy but mostly works) */
+    display: -ms-flexbox;      /* TWEENER - IE 10 */
+    display: -webkit-flex;     /* NEW - Chrome */
+    display: flex;             /* NEW, Spec - Opera 12.1, Firefox 20+ */
     left: 0;
     // &--featured{ //May be used if it becomes necessary to center the listings for window minimization
     //     justify-content: center;


### PR DESCRIPTION
Found out IE needs a different flex/flexbox style for the carousel.  This adds in all of the CSS options to cover various browsers.

Pull code, make sure carousel looks and functions as expected for all available browsers.