### PR TITLE
fix(reviews): admin review deletion fix

### DIFF
--- a/app/js/components/quickview/reviews/UserReviews.jsx
+++ b/app/js/components/quickview/reviews/UserReviews.jsx
@@ -30,7 +30,7 @@ var UserReview = React.createClass({
         var currentUser = this.props.user;
         var reviewer = this.props.review.author.id;
 
-        if(currentUser.id == reviewer || (currentUser.stewardedOrganizations.indexOf(listingOrg) !== -1)){
+        if(currentUser.id == reviewer || currentUser.highestRole == "APPS_MALL_STEWARD" || (currentUser.stewardedOrganizations.indexOf(listingOrg) !== -1)){
             return true;
         }
         return false;


### PR DESCRIPTION
Gives admins the ability to delete reviews for listings they do not own.

Closes #AMLOS-540

**Description**
As a Mall Admin, I cannot delete any reviews that are not created by me.

**Acceptance Criteria**
Users can delete and edit only their reviews
Org stewards can delete reviews for listings they are stewards of. 
Mall admins (site stewards) can delete reviews for any listing.

**How To Test**
Pull this branch
log in as (user below) and check that mallrats review can/cannot be deleted as expected.
Bigbrother: Can Delete
Wsmith: Cannot Delete
Obrien: Can Delete
Johnson: Cannot Delete
Rutherford: Can Delete