### PR TITLE
feat(listing): require and display feedback when a user pends a listing for deletion

### DIFF
--- a/app/js/components/management/user/RecentActivity.jsx
+++ b/app/js/components/management/user/RecentActivity.jsx
@@ -58,6 +58,7 @@ var RecentActivity = React.createClass({
             'ADD_RELATED_TO_ITEM',
             'REMOVE_RELATED_TO_ITEM',
             'REJECTED',
+            'PENDING_DELETION',
             'TAG_CREATED',
             'DELETED'
         ];
@@ -74,8 +75,7 @@ var RecentActivity = React.createClass({
                 'APPROVED_ORG' : 'Review Listing',
                 'REVIEWED' : 'View',
                 'REVIEW_EDITED' : 'View',
-                'REVIEW_DELETED' : 'View',
-                'PENDING_DELETION' : 'View'
+                'REVIEW_DELETED' : 'View'
             };
 
             var href = this.makeHref(this.getActiveRoutePath(), this.getParams(), {

--- a/app/js/components/shared/ChangeLog.jsx
+++ b/app/js/components/shared/ChangeLog.jsx
@@ -42,10 +42,21 @@ var ActionChangeLog = React.createClass({
 var PendingDeletionChangeLog = React.createClass({
     render: function() {
         var changeLog = this.props.changeLog;
+        var details = 'Details: ' + changeLog.description;
+        var id = uuid();
+        
         return (
             <div>
-                <AuthorLink author={changeLog.author} />
-                <span> submitted { this.props.listingName } for deletion</span>
+                <div>
+                    <AuthorLink author={changeLog.author} />
+                    <span> submitted { this.props.listingName } for deletion</span>
+                </div>
+                <a data-toggle="collapse" data-target={ '#' + id } onClick={ this.toggleIcon }>
+                    <i className="icon-plus-10-blueDark"></i> Feedback
+                </a>
+                <ul id={ id } className="collapse list-unstyled ListingActivity__Changes">
+                    <li>{ details }</li>
+                </ul>
             </div>
         );
     }

--- a/app/js/services/ListingService.js
+++ b/app/js/services/ListingService.js
@@ -305,15 +305,16 @@ ListingActions.disable.listen(setEnabled.bind(null, false));
 ListingActions.enableBookmarked.listen(setEnabledBookmarked.bind(null, true));
 ListingActions.disableBookmarked.listen(setEnabledBookmarked.bind(null, false));
 
-ListingActions.pendingDelete.listen(function (listing) {
+ListingActions.pendingDelete.listen(function (listing, description) {
     //OzpAnalytics.trackListingApproval(listing.title, listing.agencyShort);
     var data = _.cloneDeep(listing);
     data.approvalStatus = "PENDING_DELETION";
-    data.isEnabled=false;
-    ListingApi.save(data)
-    .then(ListingActions.pendingDeleteCompleted.bind(null, data))
-    .then(() => ListingActions.listingChangeCompleted(data))
-    .fail(ListingActions.pendingDeleteFailed);
+    data.isEnabled = false;
+
+    ListingApi.pendDeleteListing(listing.id, description)
+        .then(ListingActions.pendingDeleteCompleted.bind(null, data))
+        .then(() => ListingActions.listingChangeCompleted(data))
+        .fail(ListingActions.pendingDeleteFailed);
 });
 
 ListingActions.approve.listen(function (listing) {

--- a/app/js/stores/GlobalListingStore.js
+++ b/app/js/stores/GlobalListingStore.js
@@ -28,7 +28,7 @@ function updateOwnerCache (listings) {
 
 function updateCacheFromPaginatedResponse (listingsAsPaginatedResponse) {
     var listings = listingsAsPaginatedResponse.getItemAsList();
-    
+
     updateCache(listings);
 }
 
@@ -96,15 +96,15 @@ var GlobalListingStore = Reflux.createStore({
             this.trigger();
         });
         this.listenTo(ListingActions.pendingDeleteCompleted, function (data) {
-          var listing = data;
-          listing.owners.forEach(function (owner) {
-              var ownedListings = _listingsByOwnerCache.filter(function (item) {
-                  return item.id !== listing.id;
-              });
-              _listingsByOwnerCache = ownedListings;
-          });
-          ListingActions.fetchChangeLogs(listing.id);
-          this.trigger();
+            var listing = data;
+            listing.owners.forEach(function (owner) {
+                var ownedListings = _listingsByOwnerCache.filter(function (item) {
+                    return item.id !== listing.id;
+                });
+                _listingsByOwnerCache = ownedListings;
+            });
+            ListingActions.fetchChangeLogs(listing.id);
+            this.trigger();
         });
         this.listenTo(ListingActions.fetchByIdCompleted, function (data) {
             data.isPartialListing = false;

--- a/app/js/webapi/Listing.js
+++ b/app/js/webapi/Listing.js
@@ -465,6 +465,16 @@ var ListingApi = {
         });
     },
 
+    pendDeleteListing: function (id, description) {
+        return $.ajax({
+            type: 'POST',
+            url: API_URL + '/api/listing/' + id + '/pendingdeletion/',
+            data: JSON.stringify({description: description}),
+            dataType: 'json',
+            contentType: 'application/json'
+        });
+    },
+
     getAllListings: function (url, options) {
         if (!_.isString(url)) {
             url = API_URL + '/api/listing/?' + $.param(options);


### PR DESCRIPTION
AMLOS-449

**Description**     
As the administrator, I would like to capture the reason for deleting a listing by requiring the user to submit reason during the deletion process.

**Acceptance Criteria**   
1. include feedback form in the deletion process
2. require the user to provide feedback in order to complete the process

Log in as jones
Go to Listing Management > My Listings
Pend a listing for deletion.  Ensure that you are forced to enter a reason.

Log in as bigbrother
Go to the Administration tab of the listing.  Ensure you see the reason set by jones.
Go to Listing Management > Recent Activity.  Ensure you see the reason set by jones.

**How to test code**    
Checkout `pending_deletion_feedback` from `ozp-center`
Checkout `pending_deletion_feedback` from `ozp-backend`