### PR TITLE
Older browsers don't support just column-count, need to add the -moz …

### DIFF
--- a/app/styles/_quickview.scss
+++ b/app/styles/_quickview.scss
@@ -490,8 +490,10 @@ ul.list-unstyled.RecentActivity
 }
 
 .LaunchConfirmation__columns {
-    column-count: 2;
-    padding-bottom: 45px;
+  column-count: 2;
+  -moz-colomn-count: 2;
+  -webkit-column-count: 2;
+  padding-bottom: 45px;
 
     p {
         -webkit-column-break-inside: avoid;


### PR DESCRIPTION
…and -webkit variations

Another hard one to test...

`column-count` works on the current Chrome/FF, but not older browsers.

Adding -moz & -webkit versions appear to fix the column layout for Usage / System requirements, so they are displayed in two columns instead of one.
