### PR TITLE
feat(listing): require feedback when deleting a listing

### DIFF
--- a/app/js/components/quickview/AdministrationTab.jsx
+++ b/app/js/components/quickview/AdministrationTab.jsx
@@ -111,7 +111,16 @@ var AdministrationTab = React.createClass({
 
     getInitialState: function () {
         PaginatedChangeLogByIDStore.resetChangeLogByIDStore();
-        return { prevId: this.props.listing.id, editingReviewRejection: false, editingDeleteRejection: false, hasMore: true, changeLogs: [], loading: false, loadingError: false  };
+        return {
+            prevId: this.props.listing.id,
+            editingReviewRejection: false,
+            editingDeleteRejection: false,
+            editingDeleteApproval: false,
+            hasMore: true,
+            changeLogs: [],
+            loading: false,
+            loadingError: false
+        };
     },
 
     componentWillMount: function(){
@@ -282,6 +291,7 @@ var AdministrationTab = React.createClass({
     renderReviewSection: function () {
         var editingReviewNote = this.state.editingReviewRejection;
         var editingDeleteNote = this.state.editingDeleteRejection;
+        var editingDeleteApproval = this.state.editingDeleteApproval;
 
         var Justification = form.createForm(
             struct({ description: subtype(Str, s => s.length >= 1 && s.length <= 2000) }),
@@ -322,13 +332,25 @@ var AdministrationTab = React.createClass({
                     </form>
                 </section>
             );
+        } else if (editingDeleteApproval) {
+            return (
+                <section className="return-feedback">
+                    <h5>Approve Deletion Feedback</h5>
+                    <p>Please enter a reason for deleting the listing.</p>
+                    <form>
+                        <Justification ref="justification" />
+                        <button type="button" className="btn btn-default" onClick={ this.cancelApproval }>Cancel</button>
+                        <button type="button" className="btn btn-success" onClick={ this.approveDelete }>Approve Deletion</button>
+                    </form>
+                </section>
+            );
         } else {
             if (pendingDelete){
               if(isAdmin && !isStewardOfOrg) {
                 return (
                     <section className="review-listing">
                         <h5>{"Listing Pending Deletion"}</h5>
-                        <button type="button" className="btn btn-success" onClick={ this.approveDelete }>{"Approve deletion for " + agency}</button>
+                        <button type="button" className="btn btn-success" onClick={ this.editDeleteApproval }>{"Approve deletion for " + agency}</button>
                         <button type="button" className="btn btn-warning" onClick={ this.editDeleteRejection }>{"Reject deletion for " + agency}</button>
                     </section>
                 );
@@ -336,7 +358,7 @@ var AdministrationTab = React.createClass({
                   return (
                       <section className="review-listing">
                          <h5>{"Listing Pending Deletion"}</h5>
-                          <button type="button" className="btn btn-success" onClick={ this.approveDelete }>Approve deletion</button>
+                          <button type="button" className="btn btn-success" onClick={ this.editDeleteApproval }>Approve deletion</button>
                           <button type="button" className="btn btn-warning" onClick={ this.editDeleteRejection }>Reject Deletion</button>
                        </section>
                   );
@@ -377,6 +399,11 @@ var AdministrationTab = React.createClass({
         }
     },
 
+    editDeleteApproval: function (event) {
+        event.preventDefault();
+        this.setState({ editingDeleteApproval: true });
+    },
+
     editReviewRejection: function (event) {
         event.preventDefault();
         this.setState({ editingReviewRejection: true });
@@ -399,6 +426,11 @@ var AdministrationTab = React.createClass({
         }
     },
 
+    cancelApproval: function (event) {
+        event.preventDefault();
+        this.setState({ editingDeleteApproval: false });
+    },
+
     cancelRejection: function (event) {
         event.preventDefault();
         this.setState({
@@ -418,7 +450,10 @@ var AdministrationTab = React.createClass({
 
     approveDelete: function (event) {
         //event.preventDefault();
-      ListingActions.deleteListing(this.props.listing);
+        var justification = this.refs.justification.getValue();
+        if (justification) {
+            ListingActions.deleteListing(this.props.listing, justification.description);
+        }
     }
 
 });

--- a/app/js/components/shared/ChangeLog.jsx
+++ b/app/js/components/shared/ChangeLog.jsx
@@ -29,6 +29,7 @@ var AuthorLink = React.createClass({
 var ActionChangeLog = React.createClass({
     render: function() {
         var changeLog = this.props.changeLog;
+
         return (
             <div>
                 <AuthorLink author={changeLog.author} />
@@ -39,12 +40,35 @@ var ActionChangeLog = React.createClass({
     }
 });
 
+var DeletionChangeLog = React.createClass({
+    render: function() {
+        var changeLog = this.props.changeLog;
+        var details = 'Details: ' + changeLog.description;
+        var id = uuid();
+
+        return (
+            <div>
+                <div>
+                    <AuthorLink author={changeLog.author} />
+                    <span> deleted { this.props.listingName }</span>
+                </div>
+                <a data-toggle="collapse" data-target={ '#' + id } onClick={ this.toggleIcon }>
+                    <i className="icon-plus-10-blueDark"></i> Feedback
+                </a>
+                <ul id={ id } className="collapse list-unstyled ListingActivity__Changes">
+                    <li>{ details }</li>
+                </ul>
+            </div>
+        );
+    }
+});
+
 var PendingDeletionChangeLog = React.createClass({
     render: function() {
         var changeLog = this.props.changeLog;
         var details = 'Details: ' + changeLog.description;
         var id = uuid();
-        
+
         return (
             <div>
                 <div>
@@ -238,7 +262,7 @@ var ChangeLog = React.createClass({
         'CREATED' : ActionChangeLog,
         'OUTSIDE' : SetToChangeLog,
         'INSIDE' : SetToChangeLog,
-        'DELETED' : ActionChangeLog,
+        'DELETED' : DeletionChangeLog,
         'REJECTED' : RejectedChangeLog,
         'APPROVED_ORG' : OrgApprovalChangeLog,
         'REVIEWED' : ReviewedChangeLog,

--- a/app/js/components/shared/PendingDeleteConfirmation.jsx
+++ b/app/js/components/shared/PendingDeleteConfirmation.jsx
@@ -74,10 +74,11 @@ var PendingDeleteConfirmation = React.createClass({
 
     onDeleteClick: function() {
         var onDelete = this.props.onDelete,
-            requireJustification = this.props.requireJustification,
-            justification = $(this.refs.justification.getDOMNode()).val();
+            requireJustification = this.props.requireJustification;
 
         if (requireJustification) {
+            var justification = $(this.refs.justification.getDOMNode()).val();
+
             if (justification) {
                 onDelete(justification);
                 this.setState({ showJustificationError: false });

--- a/app/js/services/ListingService.js
+++ b/app/js/services/ListingService.js
@@ -339,11 +339,11 @@ ListingActions.undelete.listen(function (listing) {
     .fail(ListingActions.pendingDeleteFailed);
 });
 
-ListingActions.deleteListing.listen(function (listing) {
+ListingActions.deleteListing.listen(function (listing, description) {
     listing.isEnabled = false;
     listing.status = 'DELETED';
     listing.approvalStatus = 'DELETED';
-    ListingApi.del(listing.id)
+    ListingApi.del(listing.id, description)
         .then(ListingActions.deleteListingCompleted.bind(null, listing))
         .then(() => ListingActions.listingChangeCompleted(listing))
         .fail(ListingActions.deleteListingFailed);

--- a/app/js/webapi/Listing.js
+++ b/app/js/webapi/Listing.js
@@ -365,9 +365,10 @@ var ListingApi = {
         });
     },
 
-    del: function (id) {
+    del: function (id, description) {
         return $.ajax({
             type: 'DELETE',
+            data: { description: description },
             url: API_URL + '/api/listing/' + encodeURIComponent(id) + '/'
         });
     },


### PR DESCRIPTION
AMLOS-545

**Description**
I would like to capture the reason when an app steward deletes a listing by requiring the app steward to submit a reason during the deletion process.

**Acceptance Criteria**
1. include feedback form in the deletion process
2. require the app steward to provide feedback in order to complete the process

**How to test code**
Checkout `delete_listing_feedback` from `ozp-center`
Checkout `delete_listing_feedback` from `ozp-backend`

_Test Scenario 1_
Log in as bigbrother
Delete a listing via Listing Management
Ensure that you are required to enter a reason for deletion
Ensure that the reason displays in Listing Management > Recent Activity

_Test Scenario 2_
Log in as jones
Pend a listing for deletion
Log in as bigbrother
Go to Administration tab of listing
Approve listing for deletion
Ensure that you are required to enter a reason for deletion
Ensure that the reason displays in Listing Management > Recent Activity