### PR TITLE
fix(listing management): use org short name when filtering by org

### DIFF
--- a/app/js/components/management/shared/OrgFilter.jsx
+++ b/app/js/components/management/shared/OrgFilter.jsx
@@ -21,7 +21,7 @@ var OrgFilter = React.createClass({
             var count = (counts && counts.organizations) ? counts.organizations[organization.id] : 0;
             return (
                 <div key={ organization.id }>
-                    <input id={ "all-listings-filter-organization-" + organization.shortName.toLowerCase() } type="radio" value={ organization.title }/>
+                    <input id={ "all-listings-filter-organization-" + organization.shortName.toLowerCase() } type="radio" value={ organization.shortName }/>
                     <label htmlFor={ "all-listings-filter-organization-" + organization.shortName.toLowerCase() } className="label-organization">
                         { organization.shortName }
                         {


### PR DESCRIPTION
Fix to a bug created by https://github.com/aml-development/ozp-center/pull/925

When I refactored the organization tabs in Listing Management to use the short name instead of the full title in the URL, it broke the organization filter in the sidebar.  This update fixes that issue and closes AMLNG-801.

Special thanks to @mannyrivera2010 for uncovering this bug!