### PR TITLE
feat(category_description): increase category description length

### DIFF
--- a/app/js/components/management/mall/Categories.jsx
+++ b/app/js/components/management/mall/Categories.jsx
@@ -13,7 +13,7 @@ var Category = struct({
         return s.length <= 50;
     }),
     description: maybe(subtype(Str, function (s) {
-        return s.length <= 255;
+        return s.length <= 500;
     }))
 });
 
@@ -34,7 +34,7 @@ var Categories = React.createClass({
                     },
                     description: {
                         type: 'textarea',
-                        help: 'Max. 255 characters'
+                        help: 'Max. 500 characters'
                     }
                 }
             },


### PR DESCRIPTION
AMLOS-571

**Description**     
User submitted a ticket to increase the category description from 255 to a higher value.

**Acceptance Criteria**   
User can create or update a description of a category using more than 255 characters
 
**How to test code**    
Pull both `category_length_increase` ozp-center & ozp-backend branches

Login as a user that can create/edit categories (bigbrother)
Go to Center Settings -> Categories
Choose a category and click Edit
Verify the dialog box allows for upto 500 characters for the description.
- Says 'Max. 500 characters'
- Typing more than 500 with cause a red error
- Typing < 500 will allow for the user to submit it.


**Please Review**     
@aml-development/ozp-backend-team    


**Checklist**
- [x] Read CONTRIBUTING.md
- [x] Write code to complete task 
- [x] Python Code is PEP8 Compliant
- [x] Add unit tests for new code
- [x] All tests must pass before merging the pull request
- [ ] At least 2 people reviewed code

