### PR TITLE
fix: fix review time posted

### DIFF
--- a/app/js/components/quickview/reviews/UserReviews.jsx
+++ b/app/js/components/quickview/reviews/UserReviews.jsx
@@ -54,7 +54,7 @@ var UserReview = React.createClass({
 
     render: function () {
         var { review, onEdit, listing, user } = this.props;
-        var time = review.editedDate || review.createdDate || "";
+        var time = review.createdDate || "";
 
         return (
             <li className="Review">


### PR DESCRIPTION
fixes review showing a different timestamp when editted. 

How to test:
1. Login and post a review on a certain listing.
2. Logout and login as a different user and post a review on the same listing above.
3. Logout and log back in with the account you used in step 1.
4. Edit the original review you have created. Time shouldn't change nor position.