### PR TITLE
fix: fix the small banner icon not resizing within div

### DIFF
--- a/app/styles/listing/_search-listing-tile.scss
+++ b/app/styles/listing/_search-listing-tile.scss
@@ -37,6 +37,8 @@
 
     img {
         margin: 0 auto;
+        max-width: 100%;
+        max-height: 100%;
         display: block;
     }
 


### PR DESCRIPTION
Go to Homepage
There are some app listings that display a blown up version of small banner in thumbnail.
View on Homepage. 

Should have images fit within div now.
